### PR TITLE
Updating container image to use OC 3.9.x and the Stable Ansible 2.5

### DIFF
--- a/images/openshift-applier/Dockerfile
+++ b/images/openshift-applier/Dockerfile
@@ -1,16 +1,15 @@
 FROM centos:centos7
 
-ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.7.26/linux/oc.tar.gz
+ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.9.14/linux/oc.tar.gz
+ENV ANSIBLE_RPM http://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.5.0-1.el7.ans.noarch.rpm
 
 USER root
 
-# Update System and install clients
-RUN  yum install -y epel-release; \
-  yum install -y python-pip git; \
-  pip install --upgrade pip;  \
-  pip install git+https://github.com/ansible/ansible.git@devel
-
-RUN curl $OC_CLIENT_MIRROR | tar -C /usr/local/bin/ -xzf -
+# Install Ansible and the 'oc' client
+RUN yum install -y $ANSIBLE_RPM ;\
+    curl $OC_CLIENT_MIRROR | tar -C /usr/local/bin/ -xzf - ;\
+    yum clean all ;\
+    rm -rf /var/cache/yum
 
 CMD /bin/sleep infinity
 


### PR DESCRIPTION
#### What does this PR do?
Updating the `openshift-applier` image to use the latest `oc` client + move to the stable version of Ansible 2.5 (v.s. devel). 

#### How should this be tested?
1. Follow the build step in the README.
2. Use the instructions in the image README to run a test with `openshift-applier`.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
