### PR TITLE
New role to verify replicas are ready

### DIFF
--- a/roles/openshift-replicas-ready/defaults/main.yml
+++ b/roles/openshift-replicas-ready/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+
+target_namespace: ''
+delay: 10
+retries: 30

--- a/roles/openshift-replicas-ready/tasks/main.yml
+++ b/roles/openshift-replicas-ready/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Verify Required Parameters
+  fail:
+    msg: "'resource' and 'type' Parameters Must be Provided!"
+  when: type is not defined or type|trim == '' or resource is not defined or resource|trim == ''
+
+- name: "Set the target namespace option if supplied"
+  set_fact:
+    target_namespace: "-n {{ namespace }}"
+  when:
+  - namespace is defined
+  - namespace|trim != ''
+
+- name: Query Replica Status
+  command: >
+    oc get {{ type }}/{{ resource }} {{ target_namespace }} -o json
+  register: query_result
+  delay: "{{ delay }}"
+  retries: "{{ retries }}"
+  until: (query_result.stdout | from_json)['spec']['replicas'] | default("0") | int == (query_result.stdout | from_json)['status']['readyReplicas'] | default("0") | int
+  failed_when: (query_result.stdout | from_json)['spec']['replicas'] is not defined


### PR DESCRIPTION
#### What does this PR do?
Adds a new Role to verify replicas are in a ready state

#### How should this be tested?
The following playbook can be used to verify replicas are ready for a given deployment

```
- hosts: localhost
  connection: local
  gather_facts: no
  roles:
    - role: openshift-replicas-ready
      namespace: <namespace>
      type: <type such as dc>
      resource: <name of he resource>
```

#### Is there a relevant Issue open for this?
No

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier @oybed 
