### PR TITLE
Adding error when unsupported inventory is used

### DIFF
--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -78,8 +78,6 @@ The pre/post definitions are a set of pre and post roles to execute before/after
 
 You can source a directory composed of static files (without parameters) using `files` instead of defining each file individually.
 
-NOTE: Formerly, this was done using a separate `content_dir` structure. This has been deprecated.
-
 That would look like this:
 ```yaml
 - object: policy
@@ -171,7 +169,7 @@ Valid `action` values are `apply`, `create`, and `delete`.
 
 ### Filtering content based on tags
 
-The `openshift-applier` supports the use of tags in the inventory (see example above) to allow for filtering which content should be processed and not. The `filter_tags` variable/fact takes a comma separated list of tags that will be processed and only content/content_dir with matching tags will be applied.
+The `openshift-applier` supports the use of tags in the inventory (see example above) to allow for filtering which content should be processed and not. The `filter_tags` variable/fact takes a comma separated list of tags that will be processed and only content with matching tags will be applied.
 
 **_NOTE:_** Entries in the inventory without tags will not be processed when a valid list is supplied with the `filter_tags` option.
 

--- a/roles/openshift-applier/filter_plugins/applier-filters.py
+++ b/roles/openshift-applier/filter_plugins/applier-filters.py
@@ -12,7 +12,7 @@ def filter_content(content_dict, outer_list, filter_list):
     # If none of the filter tags exists, remove it from the list
     if len(intersect_list) == 0:
         outer_list.remove(content_dict)
-    
+
 
 # Main 'filter_applier_items' function
 def filter_applier_items(applier_list, filter_tags):
@@ -20,7 +20,7 @@ def filter_applier_items(applier_list, filter_tags):
     if len(filter_tags.strip()) == 0:
         return applier_list
 
-    # Convert comma seperated list to an actual list and strip off whitespaces of each element 
+    # Convert comma seperated list to an actual list and strip off whitespaces of each element
     filter_list = filter_tags.split(",")
     filter_list = [i.strip() for i in filter_list]
 
@@ -33,11 +33,7 @@ def filter_applier_items(applier_list, filter_tags):
                 filter_content(c, a['content'], filter_list)
 
             if len(a['content']) == 0:
-                applier_list.remove(a)		 
-
-        # Handle the 'content_dir' entries
-        elif 'content_dir' in a:
-            filter_content(a, applier_list, filter_list)
+                applier_list.remove(a)
 
     return applier_list
 
@@ -49,4 +45,3 @@ class FilterModule(object):
         return {
             'filter_applier_items': filter_applier_items
         }
-

--- a/roles/openshift-applier/tasks/copy-inventory-content.yml
+++ b/roles/openshift-applier/tasks/copy-inventory-content.yml
@@ -7,11 +7,4 @@
   with_items:
   - "{{ content_entry.content }}"
   when:
-  - content_entry.content is defined 
-
-- name: "Copy 'content_dir' entries"
-  vars:
-    dir: "{{ content_entry.content_dir }}"
-  import_tasks: copy-inventory-dir.yml
-  when:
-  - content_entry.content_dir is defined 
+  - content_entry.content is defined

--- a/roles/openshift-applier/tasks/copy-inventory-dir.yml
+++ b/roles/openshift-applier/tasks/copy-inventory-dir.yml
@@ -1,7 +1,0 @@
----
-
-- name: "Copy dir to target directory"
-  copy: 
-    src: "{{ dir }}/"
-    dest: "{{ tmp_inv_dir }}{{ dir }}"
-  failed_when: false

--- a/roles/openshift-applier/tasks/error-on-unsupported.yml
+++ b/roles/openshift-applier/tasks/error-on-unsupported.yml
@@ -1,0 +1,19 @@
+---
+
+- name: "Look for unsupported top-level dictionary entries"
+  fail:
+    msg: "Unsupported inventory entry found: {{ item }}"
+  when:
+  - openshift_cluster_content | selectattr(item, 'defined')|list|length > 0
+  with_items:
+  - "{{ unsupported_dict_top_level }}"
+
+- name: "Look for unsupported content-level dictionary entries"
+  fail:
+    msg: "Unsupported inventory entry found: {{ item.1 }}"
+  when:
+  - item.0.content is defined
+  - item.0.content | selectattr(item.1, 'defined')|list|length > 0
+  with_nested:
+  - "{{ openshift_cluster_content }}"
+  - "{{ unsupported_dict_content_level }}"

--- a/roles/openshift-applier/tasks/error-on-unsupported.yml
+++ b/roles/openshift-applier/tasks/error-on-unsupported.yml
@@ -20,7 +20,7 @@
 
 - name: "Error out if any unsupported items were found"
   fail:
-    msg: "Unsupported inventory entry found: {{ item.key }} ({{ item.value }})"
+    msg: "One or more unsupported inventory entry found for the following key: {{ item.key }}"
   when:
   - unsupported_items is defined
   with_dict: "{{ unsupported_items }}"

--- a/roles/openshift-applier/tasks/error-on-unsupported.yml
+++ b/roles/openshift-applier/tasks/error-on-unsupported.yml
@@ -1,19 +1,26 @@
 ---
 
 - name: "Look for unsupported top-level dictionary entries"
-  fail:
-    msg: "Unsupported inventory entry found: {{ item }}"
+  set_fact:
+    unsupported_items: "{{ unsupported_items | default({}) | combine({item: (openshift_cluster_content|selectattr(item, 'defined')|list|length)}) }}"
   when:
   - openshift_cluster_content | selectattr(item, 'defined')|list|length > 0
   with_items:
   - "{{ unsupported_dict_top_level }}"
 
 - name: "Look for unsupported content-level dictionary entries"
-  fail:
-    msg: "Unsupported inventory entry found: {{ item.1 }}"
+  set_fact:
+    unsupported_items: "{{ unsupported_items | default({}) | combine({item.1: (item.0.content|selectattr(item.1, 'defined')|list|length)}) }}"
   when:
   - item.0.content is defined
   - item.0.content | selectattr(item.1, 'defined')|list|length > 0
   with_nested:
   - "{{ openshift_cluster_content }}"
   - "{{ unsupported_dict_content_level }}"
+
+- name: "Error out if any unsupported items were found"
+  fail:
+    msg: "Unsupported inventory entry found: {{ item.key }} ({{ item.value }})"
+  when:
+  - unsupported_items is defined
+  with_dict: "{{ unsupported_items }}"

--- a/roles/openshift-applier/tasks/main.yml
+++ b/roles/openshift-applier/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 
+- name: "Error out on anything in the inventory that is no longer supported"
+  include_tasks: error-on-unsupported.yml
+
 - name: "Pull in Galaxy requirements - if set"
   include_tasks: install-dependencies.yml
   with_items:
@@ -22,4 +25,4 @@
   loop_control:
     loop_var: entry
   when:
-  - entry.content is defined or entry.content_dir is defined
+  - entry.content is defined

--- a/roles/openshift-applier/tasks/process-content.yml
+++ b/roles/openshift-applier/tasks/process-content.yml
@@ -14,17 +14,6 @@
   loop_control:
     loop_var: content
 
-- name: "Apply OpenShift Cluster Content ('{{ entry.object }}') - based on directory"
-  block:
-  - fail:
-      msg: "WARNING: This functionality is being deprecated. Please use the 'content.file' variable instead. See role docs for more info."
-    ignore_errors: true
-  - command: >
-      oc apply -f {{ tmp_inv_dir }}{{ entry.content_dir }}
-  when:
-  - entry.content_dir is defined
-  - entry.content_dir|trim != ''
-
 - name: "Include any post-processing role(s) after applying content"
   include_tasks: pre-post-step.yml
   with_items:

--- a/roles/openshift-applier/vars/main.yml
+++ b/roles/openshift-applier/vars/main.yml
@@ -1,0 +1,8 @@
+---
+
+unsupported_dict_top_level:
+- content_dir
+
+unsupported_dict_content_level:
+- file_action
+- template_action


### PR DESCRIPTION
#### What does this PR do?
This PR implements the check for an old/invalid inventory. This is mostly done to protect the user from utilizing an inventory believed to be valid but is not due to how some inventory variables have been eliminated - for example `content_dir`, `file_action` and `template_action`. 

#### How should this be tested?
Run the `openshift-seed-content.yml` playbook with an inventory that has any of the old inventory values (listed above) and watch the run error out. Running with an inventory per the [current documentation](https://github.com/redhat-cop/openshift-applier/blob/master/roles/openshift-applier/README.md) should **not** error out. 

#### Is there a relevant Issue open for this?
resolves #37 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
