### PR TITLE
Revert variable to target_namespace

### DIFF
--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -7,7 +7,7 @@
 - name: "{{ oc_action | capitalize }} OpenShift objects based on static files for '{{ entry.object}} : {{ content.name | default(file | basename) }}'"
   command: >
     oc {{ oc_action }} \
-       {{ oc_target_namespace }} \
+       {{ target_namespace }} \
        -f {{ file_facts['oc_file_path'] }} \
        {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }}
   register: command_result

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -2,7 +2,7 @@
 
 - name: "Set default values"
   set_fact:
-    oc_target_namespace: ''
+    target_namespace: ''
     oc_action: "{{ content.action | default(default_oc_action) }}"
     file: "{{ content.file | default('') }}"
     template: "{{ content.template | default('') }}"
@@ -17,7 +17,7 @@
 
 - name: "Set the target namespace option if supplied"
   set_fact:
-    oc_target_namespace: "-n {{ content.namespace }}"
+    target_namespace: "-n {{ content.namespace }}"
   when:
   - content.namespace is defined
   - content.namespace|trim != ''

--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -45,13 +45,13 @@
     oc process \
        {{ template_facts['oc_process_local'] }} \
        {{ template_facts['oc_option_f'] }} {{ template_facts['oc_file_path'] }} \
-       {{ oc_target_namespace }} \
+       {{ target_namespace }} \
        {{ oc_param_option }} \
        {{ oc_param_file_item }} \
        --ignore-unknown-parameters \
        | \
     oc {{ oc_action }} \
-       {{ oc_target_namespace }} \
+       {{ target_namespace }} \
        -f - \
        {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }}
   register: command_result


### PR DESCRIPTION
#### What does this PR do?
This reverts a recent change to change the `target_namespace` variable to `oc_target_namespace`. This is causing issues, as seen in #41 , so we're reverting this back to `target_namespace`.

#### How should this be tested?
Run tests similar to #41 and we should no longer see these errors.

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier @oybed 
