### PR TITLE
Added support for no_log option

### DIFF
--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -49,11 +49,13 @@ openshift_cluster_content:
           <key1>: <value1>  
     file: <file source>
     action: <apply|create> # Optional: Defaults to 'apply'
+    no_log: <True|False> # Optional: no_log at content level if functionality desired. Defaults to False
     tags: # Optional: Tags are only needed if `filter_tags` is used
     - tag1
     - tag2
     post_steps: # Optional: post-steps at content level can be added if desired
       - role: <path to an ansible role>
+  no_log: <True|False> # Optional: no_log at object level if functionality desired. Optional: Defaults to False
   post_steps: # Optional: post-steps at object level can be added if desired
     - role: <path to an ansible role>
 - object: <object_type>
@@ -177,6 +179,10 @@ The `openshift-applier` supports the use of tags in the inventory (see example a
 filter_tags=tag1,tag2
 
 ```
+
+### Suppressing Log Output
+
+Output can be suppressed either at the `object` or `content` level when there is a desire to suppress secret values from being displayed.
 
 ### Pre/Post steps
 

--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -10,6 +10,7 @@
        {{ target_namespace }} \
        -f {{ file_facts['oc_file_path'] }} \
        {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }}
+  no_log: "{{ no_log }}"
   register: command_result
   failed_when:
   - command_result.rc != 0

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -16,7 +16,7 @@
   when:
   - not provision|bool
 
-- name: "Set no_log when speified"
+- name: "Set no_log when specified"
   set_fact:
     no_log: True
   when: (entry.no_log is defined and entry.no_log|bool) or (content.no_log is defined and content.no_log|bool)

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -8,12 +8,18 @@
     template: "{{ content.template | default('') }}"
     params: "{{ content.params | default('') }}"
     params_from_vars: "{{ content.params_from_vars | default({}) }}"
+    no_log: False
 
 - name: "Set oc_action to delete when in deprovision mode"
   set_fact:
     oc_action: "delete"
   when:
   - not provision|bool
+
+- name: "Set no_log when speified"
+  set_fact:
+    no_log: True
+  when: (entry.no_log is defined and entry.no_log|bool) or (content.no_log is defined and content.no_log|bool)
 
 - name: "Set the target namespace option if supplied"
   set_fact:

--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -55,6 +55,7 @@
        -f - \
        {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }}
   register: command_result
+  no_log: "{{ no_log }}"
   failed_when:
   - command_result.rc != 0
   - "'AlreadyExists' not in command_result.stderr"


### PR DESCRIPTION
#### What does this PR do?
Adds support for the `no_log` Ansible option

#### How should this be tested?
Add `no_log: True` at either the content or object level to an inventory. When testing, add the `-vvv` option and validate output is successfully suppressed

#### Is there a relevant Issue open for this?
Resolves #43 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
