### PR TITLE
Eliminate the 'requests' python dependency

### DIFF
--- a/images/openshift-applier/Dockerfile
+++ b/images/openshift-applier/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:centos7
 
-ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.9.14/linux/oc.tar.gz
-ENV ANSIBLE_RPM http://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.5.0-1.el7.ans.noarch.rpm
+ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.10.0-0.69.0/linux/oc.tar.gz
+ENV ANSIBLE_RPM https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.5.8-1.el7.ans.noarch.rpm
 ENV INSTALL_PKGS "git"
 ENV WORK_DIR /openshift-applier
 ENV HOME ${WORK_DIR}

--- a/roles/openshift-applier/defaults/main.yml
+++ b/roles/openshift-applier/defaults/main.yml
@@ -1,8 +1,9 @@
 ---
 
-default_oc_action: apply
 tmp_inv_dir: ''
 filter_tags: ''
 provision: True
 params_from_vars: {}
+
+oc_action: apply
 oc_ignore_unknown_parameters: true

--- a/roles/openshift-applier/defaults/main.yml
+++ b/roles/openshift-applier/defaults/main.yml
@@ -1,9 +1,8 @@
 ---
 
+default_oc_action: apply
 tmp_inv_dir: ''
 filter_tags: ''
 provision: True
 params_from_vars: {}
-
-oc_action: apply
 oc_ignore_unknown_parameters: true

--- a/roles/openshift-applier/filter_plugins/applier-filters.py
+++ b/roles/openshift-applier/filter_plugins/applier-filters.py
@@ -50,15 +50,17 @@ def check_file_location(path, tmp_inv_dir):
         "oc_process_local": ''
     }
 
-    # default return status for url and file checks
+    # default return status to false
     url_status = False
-    file_status = False
 
-    # First try to see if this is a URL - if it is not, check for local file
-    try:
-        url_status = urllib.urlopen(path)
-    except:
-        file_status = os.path.isfile("%s%s" % (tmp_inv_dir, path))
+    # First try to see if this is a local file - if it is not, check for a valid URL
+    file_status = os.path.isfile("%s%s" % (tmp_inv_dir, path))
+    if (not file_status):
+        try:
+            url_status = urllib.urlopen(path)
+        except:
+            # Both check failed - return "default" values
+            return return_vals
 
     # If it is a valid URL or local file, set the proper flags
     if ((url_status and url_status.getcode() == 200) or file_status):

--- a/roles/openshift-applier/filter_plugins/applier-filters.py
+++ b/roles/openshift-applier/filter_plugins/applier-filters.py
@@ -1,5 +1,7 @@
 import os
-import requests
+import urllib
+from urlparse import urlparse
+
 
 # Helper function to simplify the 'filter_applier_items' below
 def filter_content(content_dict, outer_list, filter_list):
@@ -39,27 +41,33 @@ def filter_applier_items(applier_list, filter_tags):
 
     return applier_list
 
+# Function used to determine a files location - i.e.: URL, local file or "something else"
 def check_file_location(path, tmp_inv_dir):
+    # default return values
     return_vals = {
         "oc_option_f":  '',
         "oc_file_path": path,
         "oc_process_local": ''
     }
 
-    file_status = os.path.isfile("%s%s" % (tmp_inv_dir,path))
+    # default return status for url and file checks
+    url_status = False
+    file_status = False
 
-    if(not file_status):
-        try:
-            request_status = requests.head(path)
-        except requests.exceptions.MissingSchema:
-            return return_vals
+    # First try to see if this is a URL - if it is not, check for local file
+    try:
+        url_status = urllib.urlopen(path)
+    except:
+        file_status = os.path.isfile("%s%s" % (tmp_inv_dir, path))
 
-    if (file_status or request_status.status_code == 200):
+    # If it is a valid URL or local file, set the proper flags
+    if ((url_status and url_status.getcode() == 200) or file_status):
         return_vals['oc_option_f'] = ' -f'
         return_vals['oc_process_local'] = ' --local'
 
+    # Ensure the correct path is used for the file if it is a local file
     if (file_status):
-        return_vals['oc_file_path'] = "%s%s" % (tmp_inv_dir,path)
+        return_vals['oc_file_path'] = "%s%s" % (tmp_inv_dir, path)
 
     return return_vals
 

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -3,7 +3,7 @@
 - name: "Set default values"
   set_fact:
     target_namespace: ''
-    oc_action: "{{ content.action | default(default_oc_action) }}"
+    oc_action: "{{ content.action | default(oc_action) }}"
     file: "{{ content.file | default('') }}"
     template: "{{ content.template | default('') }}"
     params: "{{ content.params | default('') }}"

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -3,7 +3,7 @@
 - name: "Set default values"
   set_fact:
     target_namespace: ''
-    oc_action: "{{ content.action | default(oc_action) }}"
+    oc_action: "{{ content.action | default(default_oc_action) }}"
     file: "{{ content.file | default('') }}"
     template: "{{ content.template | default('') }}"
     params: "{{ content.params | default('') }}"


### PR DESCRIPTION
#### What does this PR do?
The main purpose for this PR is to eliminate the dependency on `requests`

#### How should this be tested?
Run the tests in the `openshift-applier` 

#### Is there a relevant Issue open for this?
resolves #47 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
