### PR TITLE
process-template.yml - fix "with_dict expects a dict" error

### DIFF
--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -31,8 +31,7 @@
 - name: "Change 'params_from_vars' fact (if applicable) into command line parameters"
   set_fact:
     oc_param_option: "{{ oc_param_option }} --param={{ item.key }}={{ item.value }}"
-  with_dict:
-  - "{{ params_from_vars }}"
+  with_dict: "{{ params_from_vars }}"
 
 # This call sets the 'oc_process_local', 'oc_option_f' and 'oc_file_path' parameters
 - name: "Determine location for the 'template'"


### PR DESCRIPTION
#### What does this PR do?
Fix's an error when using this role.
Maybe specific to Ansible 2.4 but not positive.

#### How should this be tested?
Ansible 2.4
```
cicd_project_params:
  NAMESPACE: hello-world-2-cicd
  NAMESPACE_DISPLAY_NAME: Hello World 2 - CICD
  NAMESPACE_DESCRIPTION: Hello World CICD project.

openshift_cluster_content:
- object: projectrequest
  content:
  - name: Create CICD
    template: "{{ inventory_dir }}/files/templates/projectrequest.yml"
    params_from_vars: "{{ dev_project_params }}"
    action: create
```

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
