### PR TITLE
process-template.yml - need to quote template params

### DIFF
--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -30,7 +30,7 @@
 
 - name: "Change 'params_from_vars' fact (if applicable) into command line parameters"
   set_fact:
-    oc_param_option: "{{ oc_param_option }} --param={{ item.key }}={{ item.value }}"
+    oc_param_option: "{{ oc_param_option }} --param='{{ item.key }}={{ item.value }}'"
   with_dict:
   - "{{ params_from_vars }}"
 


### PR DESCRIPTION
#### What does this PR do?
Fix's an error when using this role.
Maybe specific to Ansible 2.4 but not positive.

```
failed: [localhost] (item=None) => {"changed": true, "cmd": "oc process  --local  -f /usr/local/home/uscs_sys/ian/hello-world/openshift/files/templates/projectrequest.yml   --param=NAMESPACE_DESCRIPTION=Hello World Development Integratio

n project. --param=NAMESPACE=hello-world-2-dev --param=NAMESPACE_DISPLAY_NAME=Hello World 2 - Dev  --ignore-unknown-parameters | oc create  -f - ", "delta": "0:00:00.468166", "end": "2018-08-28 21:33:26.111227", "failed": true, "failed_w

hen_result": true, "msg": "non-zero return code", "oc_param_file_item": "", "rc": 1, "start": "2018-08-28 21:33:25.643061", "stderr": "error: template name must be specified only once: Development\nSee 'oc process -h' for help and exampl

es.\nerror: no objects passed to create", "stderr_lines": ["error: template name must be specified only once: Development", "See 'oc process -h' for help and examples.", "error: no objects passed to create"], "stdout": "", "stdout_lines"

: []}
```

#### How should this be tested?
Ansible 2.4
```
cicd_project_params:
  NAMESPACE: hello-world-2-cicd
  NAMESPACE_DISPLAY_NAME: Hello World 2 - CICD
  NAMESPACE_DESCRIPTION: Hello World CICD project.

openshift_cluster_content:
- object: projectrequest
  content:
  - name: Create CICD
    template: "{{ inventory_dir }}/files/templates/projectrequest.yml"
    params_from_vars: "{{ dev_project_params }}"
    action: create
```

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
