### PR TITLE
Add ansible version precheck

### DIFF
--- a/roles/openshift-applier/tasks/main.yml
+++ b/roles/openshift-applier/tasks/main.yml
@@ -1,4 +1,6 @@
 ---
+- name: "Check applier requirements"
+  include_tasks: pre-check.yml
 
 - name: "Error out on anything in the inventory that is no longer supported"
   include_tasks: error-on-unsupported.yml

--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -1,0 +1,6 @@
+---
+- name: Exit if ansible version doesn't meet minimum requirements
+  fail:
+    msg: "openshift-applier requires at least Ansible 2.5 in order to proceed"
+  when:
+  - "ansible_version.full is version('2.5','<')"


### PR DESCRIPTION
#### What does this PR do?
This PR adds the pre-check requiring Ansible >= 2.5. It also allows us to add any other necessary pre-requisites moving forward.

#### How should this be tested?
On a machine that has Ansible < 2.5, run the applier. You'll see that it fails with a message showing that it needs to be run with version 2.5 or higher.

#### Is there a relevant Issue open for this?
#54 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
