### PR TITLE
Removing double quotes as it causes an 'unknown escape character' in …

### DIFF
--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -7,7 +7,7 @@
 
 
 - name:  "Determine oc version"
-  shell: "oc version | sed -ne 's/^oc v*\(.*\)+.*$/\1/p'" 
+  shell: oc version | sed -ne 's/^oc v*\(.*\)+.*$/\1/p'
   register: oc_vers_check
 
 - name: "Determine unknown param flag"


### PR DESCRIPTION
…YAML

#### What does this PR do?
When running the playbooks with Ansible 2.6.4 I get an error: 
```
fatal: [master2_phmcmahon_com]: FAILED! => {"reason": "Syntax Error while loading YAML.
  found unknown escape character

The error appears to have been in '/home/pmcmahon/repos/xv/ocp-lab-assignment/roles/openshift-applier/tasks/pre-check.yml': line 9, column 41, but may
be elsewhere in the file depending on the exact syntax problem.

The offending line appears to be:

- name: \"Determine oc version\"
  shell: \"oc version | sed -ne 's/^oc v*\(.*\)+.*$/\1/p'\"
                                        ^ here
"}
```

It seems that YAML is interpreting some characters as escape characters in the quoted scalar.

Similar issue [here](https://stackoverflow.com/questions/34513913/unable-to-start-filebeat-due-to-yaml-config-issue) on Stack overflow

#### How should this be tested?
The latest playbooks don't run at all for me, so I guess this can be tested by simply running the openshift-cluster-seed.yml playbook.

#### Is there a relevant Issue open for this?
I couldn't find one, but I can open one if needed. 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
