### PR TITLE
Fixing regex list v.s. string

### DIFF
--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -16,7 +16,7 @@
 
   - name: "Filter out just the oc version number"
     set_fact:
-      oc_version: "{{ oc_vers_check.stdout | regex_search('^oc.+v([\\d.]+).*', '\\1') }}" 
+      oc_version: "{{ (oc_vers_check.stdout | regex_search('^oc.+v([\\d.]+).*', '\\1'))[0] }}"
 
   - name: "Do *not* use the 'ignore_unknown_parameters' flag if 'oc' version is older than 3.7"
     set_fact:


### PR DESCRIPTION
#### What does this PR do?
`regex_search` returns a list, while the check is truly for a string... this PR is fixing this. Thanks to @tomcooperca for catching this. See issue #63 for more details. 

#### How should this be tested?
Run the tests in the `tests` directory

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
