### PR TITLE
Adding option to skip version checks

### DIFF
--- a/playbooks/README.md
+++ b/playbooks/README.md
@@ -12,8 +12,21 @@ localhost
 ```
 
 2. Local Execution
-If the playbook is executed locally, i.e.: on your `localhost`, it's recommended to run with the local option ( `--connection=local` ) to speed up the execution. This prevents the inventory from being copied to the remote host (even if the remote host is your localhost) and hence avoids the extra time it takes to iterate over the inventory content to copy the local files.
+If the playbook is executed locally, i.e.: on your `localhost`, it's recommended to run with the local option ( `--connection=local` ) to speed up the execution. This prevents the inventory from being copied to the remote host and hence avoids the extra time it takes to iterate over the inventory content to copy the local files.
+
+**Tip:** Adding the following to `host_vars/localhost.yml` allows you to skip the command line argument:
 
 ```
-ansible-playbook -i <inventory> path/to/openshift-applier/playbooks/openshift-cluster-seed.yml --connection=local
+ansible_connection: local
+```
+
+```
+> ansible-playbook -i <inventory> path/to/openshift-applier/playbooks/openshift-cluster-seed.yml --connection=local
+```
+
+3. Skip Version Checks
+The [openshift-applier](../roles/openshift-applier) by default enforces that the appropriate versions of ansible, oc, etc. is used and will error out of minimum requirements are not met. However, in some cases you may want/need to by-pass this check and run with other versions. This can be done by setting the `skip_version_check` flag - either on the command line or part of your inventory (the latter is not recommended):
+
+```
+> ansible-playbook -i <inventory> path/to/openshift-applier/playbooks/openshift-cluster-seed.yml -e 'skip_version_checks=True'
 ```

--- a/roles/openshift-applier/tasks/main.yml
+++ b/roles/openshift-applier/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: "Check applier requirements"
   include_tasks: pre-check.yml
 

--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -1,30 +1,35 @@
 ---
 
-- name: "Exit if ansible version doesn't meet minimum requirements"
-  fail:
-    msg: "openshift-applier requires at least Ansible 2.5 in order to proceed"
-  when:
-    - "ansible_version.full is version('2.5','<')"
-
-- name: "Retrieve oc client version"
-  shell: oc version
-  register: oc_vers_check
-
-# Block to handle oc command output
-# - only proceed if the oc command returned any output
+# Block to allow version checks to be skipped
 - block:
 
-    - name: "Filter out just the oc version number"
-      set_fact:
-        oc_version: "{{ (oc_vers_check.stdout | regex_search('^oc.+v([\\d.]+).*', '\\1'))[0] }}"
-
-    - name: "Do *not* use the 'ignore_unknown_parameters' flag if 'oc' version is older than 3.7"
-      set_fact:
-        oc_ignore_unknown_parameters: false
+    - name: "Exit if ansible version doesn't meet minimum requirements"
+      fail:
+        msg: "openshift-applier requires at least Ansible 2.5 in order to proceed"
       when:
-        - oc_version is version('3.7','<')
+        - "ansible_version.full is version('2.5','<')"
 
+    - name: "Retrieve oc client version"
+      shell: oc version
+      register: oc_vers_check
+
+    # Block to handle oc command output
+    # - only proceed if the oc command returned any output
+    - block:
+
+        - name: "Filter out just the oc version number"
+          set_fact:
+            oc_version: "{{ (oc_vers_check.stdout | regex_search('^oc.+v([\\d.]+).*', '\\1'))[0] }}"
+
+        - name: "Do *not* use the 'ignore_unknown_parameters' flag if 'oc' version is older than 3.7"
+          set_fact:
+            oc_ignore_unknown_parameters: false
+          when:
+            - oc_version is version('3.7','<')
+
+      when:
+        - oc_vers_check is defined
+        - oc_vers_check.stdout is defined
+        - oc_vers_check.stdout|trim != ""
   when:
-    - oc_vers_check is defined
-    - oc_vers_check.stdout is defined
-    - oc_vers_check.stdout|trim != ""
+    - skip_version_checks is undefined


### PR DESCRIPTION
#### What does this PR do?
In some cases it may be necessary to skip the versions pre-checks. This PR introduces as flag (`skip_version_checks`) that allows for this. 

#### How should this be tested?
Run the openshift-applier playbook on a host with Ansible or oc not meeting the minimum requirements (2.5 for Ansible and 3.7 for oc). Observe that the execution errors out due to pre-check. Re-run with the `-e skip_version_checks=True` flag set and observe that the execution works. 

#### Is there a relevant Issue open for this?
resolves #73 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
