### PR TITLE
Fixing URL getting /tmp/xyz path for remote execution

### DIFF
--- a/roles/openshift-applier/tasks/copy-inventory-file-to-remote.yml
+++ b/roles/openshift-applier/tasks/copy-inventory-file-to-remote.yml
@@ -1,14 +1,32 @@
 ---
 
-- name: "Create target directory to ensure it exists"
-  file:
-    path: "{{ tmp_inv_dir }}{{ file|dirname }}"
-    state: directory
-  when:
-    - file|dirname != ''
+- name: "Determine location for the file"
+  set_fact:
+    tmp_file_facts: "{{ file | check_file_location }}"
 
-- name: "Copy file to target directory"
-  copy:
-    src: "{{ file }}"
-    dest: "{{ tmp_inv_dir }}{{ file }}"
-  failed_when: false
+- block:
+    - name: "Create target directory to ensure it exists"
+      file:
+        path: "{{ tmp_inv_dir }}{{ file|dirname }}"
+        state: directory
+      when:
+        - file|dirname != ''
+
+    - name: "Copy file to target directory"
+      copy:
+        src: "{{ file }}"
+        dest: "{{ tmp_inv_dir }}{{ file }}"
+      failed_when: false
+
+    - name: "Update file path to include the tmp_inv_dir path"
+      set_fact:
+        tmp_file_facts: "{{ tmp_file_facts|combine(new_value, recursive=true) }}"
+      vars:
+        new_value: "{ 'oc_path': '{{ tmp_inv_dir }}{{ file }}' }"
+  when:
+    - tmp_file_facts.local_path
+    - ansible_connection != 'local'
+
+- name: "Add the processed file to the list of files"
+  set_fact:
+    file_facts: "{{ file_facts + [ tmp_file_facts ] }}"

--- a/roles/openshift-applier/tasks/copy-inventory-file-to-remote.yml
+++ b/roles/openshift-applier/tasks/copy-inventory-file-to-remote.yml
@@ -2,31 +2,31 @@
 
 - name: "Determine location for the file"
   set_fact:
-    tmp_file_facts: "{{ file | check_file_location }}"
+    tmp_file_facts: "{{ file_path | check_file_location }}"
 
 - block:
     - name: "Create target directory to ensure it exists"
       file:
-        path: "{{ tmp_inv_dir }}{{ file|dirname }}"
+        path: "{{ tmp_inv_dir }}{{ file_path|dirname }}"
         state: directory
       when:
-        - file|dirname != ''
+        - file_path|dirname != ''
 
     - name: "Copy file to target directory"
       copy:
-        src: "{{ file }}"
-        dest: "{{ tmp_inv_dir }}{{ file }}"
+        src: "{{ file_path }}"
+        dest: "{{ tmp_inv_dir }}{{ file_path }}"
       failed_when: false
 
     - name: "Update file path to include the tmp_inv_dir path"
       set_fact:
         tmp_file_facts: "{{ tmp_file_facts|combine(new_value, recursive=true) }}"
       vars:
-        new_value: "{ 'oc_path': '{{ tmp_inv_dir }}{{ file }}' }"
+        new_value: "{ 'oc_path': '{{ tmp_inv_dir }}{{ file_path }}' }"
   when:
     - tmp_file_facts.local_path
     - ansible_connection != 'local'
 
 - name: "Add the processed file to the list of files"
   set_fact:
-    file_facts: "{{ file_facts + [ tmp_file_facts ] }}"
+    processed_file_facts: "{{ processed_file_facts + [ tmp_file_facts ] }}"

--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -1,18 +1,16 @@
 ---
 
-- name: "Determine the location for the 'file'"
-  set_fact:
-    file_facts: "{{ file | check_file_location }}"
+- name: "Copy file to remote location if required"
+  block:
+    - set_fact:
+        processed_file_facts: []
+    - include_tasks: copy-inventory-file-to-remote.yml
+      vars:
+        file_path: "{{ file }}"
+    - set_fact:
+        file_facts: "{{ processed_file_facts|first }}"
 
-- name: "Copy file(s) to remote location if required"
-  vars:
-    file: "{{ file_facts.oc_path }}"
-  include_tasks: copy-inventory-file-to-remote.yml
-  when:
-    - file_facts.local_path
-    - ansible_connection != 'local'
-
-- name: "{{ oc_action | capitalize }} OpenShift objects based on static files for '{{ entry.object}} : {{ content.name | default(file | basename) }}'"
+- name: "{{ oc_action | capitalize }} OpenShift objects based on static files for '{{ entry.object }} : {{ content.name | default(file | basename) }}'"
   command: >
     oc {{ oc_action }} \
        {{ target_namespace }} \

--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -14,7 +14,7 @@
   command: >
     oc {{ oc_action }} \
        {{ target_namespace }} \
-       -f {{ tmp_inv_dir }}{{ file_facts.oc_path }} \
+       -f {{ file_facts.oc_path }} \
        {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }}
   no_log: "{{ no_log }}"
   register: command_result

--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -34,33 +34,34 @@
     oc_param_option: "{{ oc_param_option }} --param='{{ item.key }}={{ item.value }}'"
   with_dict: "{{ params_from_vars }}"
 
-# This call sets the 'oc_process_local', 'oc_option_f', 'oc_path' & 'local_path' parameters
-- name: "Determine location for the 'template'"
-  set_fact:
-    template_facts: "{{ template | check_file_location }}"
-
-- name: "Copy file(s) to remote location if required"
+- name: "Copy template and param file(s) to remote location - if required"
   block:
-    - vars:
-        file: "{{ template_facts.oc_path }}"
-      include_tasks: copy-inventory-file-to-remote.yml
-    - vars:
+    - set_fact:
+        file_facts: []
+    - include_tasks: copy-inventory-file-to-remote.yml
+      vars:
+        file: "{{ template }}"
+    - set_fact:
+        template_facts: "{{ file_facts|first }}"
+        file_facts: []
+    - include_tasks: copy-inventory-file-to-remote.yml
+      vars:
         file: "{{ item }}"
-      include_tasks: copy-inventory-file-to-remote.yml
       with_items:
         - "{{ param_file_list }}"
-  when:
-    - template_facts.local_path
-    - ansible_connection != 'local'
+    - set_fact:
+        param_facts: "{{ file_facts }}"
+        file_facts: []
+
 
 - name: "{{ oc_action | capitalize }} OpenShift objects based on template with params for '{{ entry.object}} : {{ content.name | default(template | basename) }}'"
   shell: >
     oc process \
        {{ template_facts.oc_process_local }} \
-       {{ template_facts.oc_option_f }} {{ tmp_inv_dir }}{{ template_facts.oc_path }} \
+       {{ template_facts.oc_option_f }} {{ template_facts.oc_path }} \
        {{ target_namespace }} \
        {{ oc_param_option }} \
-       {{ (oc_param_file_item|trim == '') | ternary('', ' --param-file="' + tmp_inv_dir + oc_param_file_item + '"') }} \
+       {{ (oc_param_file_item|trim == '') | ternary('', ' --param-file="' + oc_param_file_item.oc_path + '"') }} \
        {{ oc_ignore_unknown_parameters | ternary('--ignore-unknown-parameters', '') }} \
        | \
     oc {{ oc_action }} \
@@ -75,6 +76,6 @@
   # If the array is empty, make sure to run the loop at least once
   # - the "['']" will enforce that it run at least once
   with_items:
-    - "{{ (param_file_list|length > 0) | ternary(param_file_list, ['']) }}"
+    - "{{ (param_facts|length > 0) | ternary(param_facts, ['']) }}"
   loop_control:
     loop_var: 'oc_param_file_item'

--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -37,21 +37,21 @@
 - name: "Copy template and param file(s) to remote location - if required"
   block:
     - set_fact:
-        file_facts: []
+        processed_file_facts: []
     - include_tasks: copy-inventory-file-to-remote.yml
       vars:
-        file: "{{ template }}"
+        file_path: "{{ template }}"
     - set_fact:
-        template_facts: "{{ file_facts|first }}"
-        file_facts: []
+        template_facts: "{{ processed_file_facts|first }}"
+        processed_file_facts: []
     - include_tasks: copy-inventory-file-to-remote.yml
       vars:
-        file: "{{ item }}"
+        file_path: "{{ item }}"
       with_items:
         - "{{ param_file_list }}"
     - set_fact:
-        param_facts: "{{ file_facts }}"
-        file_facts: []
+        param_facts: "{{ processed_file_facts }}"
+        processed_file_facts: []
 
 
 - name: "{{ oc_action | capitalize }} OpenShift objects based on template with params for '{{ entry.object}} : {{ content.name | default(template | basename) }}'"

--- a/tests/inventories/multi-files-dir/group_vars/seed-hosts.yml
+++ b/tests/inventories/multi-files-dir/group_vars/seed-hosts.yml
@@ -10,5 +10,5 @@ openshift_cluster_content:
 - object: label-test
   content:
   - name: Create multiple routes from multiple static files in a directory
-    file: "{{ inventory_dir }}/../../files/multi-files-dir/files"
+    file: "{{ inventory_dir }}/../../files/multi-files-dir/files/"
     namespace: 'oa-ci-multi-files-dir1'


### PR DESCRIPTION
#### What does this PR do?
In some cases, when executing on a remote host, the template or file URL will be prepended with the temporary path. This has now been fixed to make sure the URL stays a URL. 

#### How should this be tested?
Run at least 3 tests:
1. Use an inventory whereas the template is a local file and the `seed-host` is a remote host
- validate that the execution works and that the files are sources / objects created correctly 

2. Use an inventory whereas the template is a remote file (URL) and the `seed-host` is a remote host
- validate that the execution works and that the files are sources / objects created correctly 

3. Repeat the above 2 for a static file

4. Repeat the first 2 with param files that are a mixture of local and remote (URL) files

#### Is there a relevant Issue open for this?
resolves #76 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
