### PR TITLE
Add module import switch for python3 support

### DIFF
--- a/roles/openshift-applier/filter_plugins/applier-filters.py
+++ b/roles/openshift-applier/filter_plugins/applier-filters.py
@@ -1,6 +1,9 @@
 import os
 import urllib
-from urlparse import urlparse
+try:
+    from urlparse import urljoin
+except ImportError:
+    from urllib.parse import urljoin
 
 
 # Helper function to simplify the 'filter_applier_items' below


### PR DESCRIPTION
 When using Python3 use `urllib.parse` instead of `urlparse`.

#### What does this PR do?
Changing the package import of `urljoin` to be compatible with Python2 and Python3

#### How should this be tested?
Run the applier with an ansible package using python3 by default as in Fedora 29 with ansible in versions `2.7.1` and `2.6.5`.

#### Is there a relevant Issue open for this?
#81 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
