### PR TITLE
Updating docs to use local user for image

### DIFF
--- a/images/openshift-applier/README.md
+++ b/images/openshift-applier/README.md
@@ -28,7 +28,7 @@ systemctl restart docker
 The simplest possible run of the image would look like:
 
 ```
-docker run  \
+docker run -u $(id -u) \
   -v $HOME/.kube/config:/openshift-applier/.kube/config:z
   -t redhat-cop/openshift-applier
 ```
@@ -43,7 +43,7 @@ Running the above command will kick off an openshift-applier run that will execu
 Running an openshift-applier inventory that you may have locally requires two things:
 
 ```
-docker run \
+docker run -u $(id -u) \
   -v $HOME/.kube/config:/openshift-applier/.kube/config:z
   -v $HOME/src/my-inventory/:/tmp/my-inventory <1>
   -e INVENTORY_PATH=/tmp/my-inventory <2>
@@ -57,7 +57,7 @@ docker run \
 For convenience, the container image packages the openshift-applier ansible code inside of the container file system at `/openshift-applier/`. By default, the run script will run the basic applier playbook at `/openshift-applier/playbooks/openshift-cluster-seed.yml`. If you would like to run your local version of applier, you can override this default by adding the following:
 
 ```
-docker run  \
+docker run -u $(id -u) \
   -v $HOME/.kube/config:/openshift-applier/.kube/config:z
   -v $HOME/src/openshift-applier/:/tmp/openshift-applier <1>
   -e PLAYBOOK=/tmp/openshift-applier/playbooks/my-new-playbook.yml <2>


### PR DESCRIPTION
#### What does this PR do?
When running the commands in images/openshift-applier/README.md as a non-root user, the container fails with:

```
TASK [openshift-applier : Retrieve oc client version] ***************************************************
Tuesday 15 January 2019  03:26:46 +0000 (0:00:00.031)       0:00:02.554 ******* 
fatal: [localhost]: FAILED! => {"changed": true, "cmd": "oc version", "delta": "0:00:00.350508", "end": "2019-01-15 03:26:46.726399", "msg": "non-zero return code", "rc": 1, "start": "2019-01-15 03:26:46.375891", "stderr": "error: Error loading config file \"/openshift-applier/.kube/config\": open /openshift-applier/.kube/config: permission denied\nSee 'oc version -h' for help and examples.", "stderr_lines": ["error: Error loading config file \"/openshift-applier/.kube/config\": open /openshift-applier/.kube/config: permission denied", "See 'oc version -h' for help and examples."], "stdout": "", "stdout_lines": []}

PLAY RECAP **********************************************************************************************
localhost                  : ok=2    changed=0    unreachable=0    failed=1   
```
#### How should this be tested?

Run the commands in images/openshift-applier/README.md

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
