### PR TITLE
FIX - Url to Ansible docs missing http://

### DIFF
--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -216,7 +216,7 @@ The pre/post steps can be added at both the `object` level as well as the `conte
 
 In essence, the pre/post steps are ansible roles that gets executed in the order they are found in the inventory. These roles are sourced from the `galaxy_requirements` file part of the inventory. See the official [Ansible Galaxy docs for more details on the requirements yaml file](http://docs.ansible.com/ansible/latest/galaxy.html#installing-multiple-roles-from-a-file).
 
-**_NOTE:_** it is important that the repos used for pre/post roles have the `meta/main.yml` file setup correctly. See the [Ansible Galaxy docs](docs.ansible.com/ansible/latest/galaxy.html) for more details.
+**_NOTE:_** it is important that the repos used for pre/post roles have the `meta/main.yml` file setup correctly. See the [Ansible Galaxy docs](http://docs.ansible.com/ansible/latest/galaxy.html) for more details.
 
 For roles that requires input parameters, the implementation also supports supplying variables, as part of the inventory, to the pre/post steps. See example at the top for more details.
 


### PR DESCRIPTION
#### What does this PR do?
Fix link to Ansible docs

#### How should this be tested?
Click on link, should not give a 404

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
