### PR TITLE
Run molecule tests against multiple versions of ansible

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 ---
-
+dist: xenial
 language: python
 python:
   - "2.7"
+  - "3.7"
 
 cache:
   directories:
@@ -26,14 +27,16 @@ install:
 before_script:
   # Configure Docker
   - sudo service docker stop
-  - sudo sed -i -e 's/sock/sock --insecure-registry 172.30.0.0\/16/' /etc/default/docker
+  - sudo mkdir -p /etc/docker
+  - echo '{"insecure-registries":["172.30.0.0/16"]}' | sudo tee /etc/docker/daemon.json
   - sudo service docker start
   # Launch OpenShift Environment
   - |
     set +e
     built=false
     while true; do
-      IP_ADDR=$(ifconfig eth0 | grep 'inet addr:' | cut -d: -f2 | awk '{ print $1}')
+      DEV=$(ip link | awk '/state UP/{ gsub(":", ""); print $2}')
+      IP_ADDR=$(ip addr show $DEV | awk '/inet /{ gsub("/.*", ""); print $2}')
       oc cluster up --public-hostname=${IP_ADDR} --routing-suffix=${IP_ADDR}.nip.io --base-dir=/home/travis/ocp
       if [ "$?" -eq 0 ]; then
         built=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,15 @@ env:
     - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
   matrix:
     - ANSIBLE_VERSION="latest"
-    - ANSIBLE_VERSION="2.6.13"
-    - ANSIBLE_VERSION="2.7.7"
+    - ANSIBLE_VERSION="2.6"
+    - ANSIBLE_VERSION="2.7"
 
 before_install:
   - sudo apt-get update -qq
 
 install:
   - pip install -U pip
-  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible; else pip install ansible==$ANSIBLE_VERSION; fi
+  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible; else pip install ansible~=$ANSIBLE_VERSION; fi
   - pip install "ansible-lint<4.0" yamllint flake8 molecule docker "pytest<3.10"
   # Configure OpenShift Binary
   - sudo wget -qO- ${OC_BINARY_URL} | sudo tar -xvz -C /bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,13 +14,18 @@ env:
     - ANSIBLE_HOST_KEY_CHECKING=False
     - PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
     - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
+  matrix:
+    - ANSIBLE_VERSION="latest"
+    - ANSIBLE_VERSION="2.6.13"
+    - ANSIBLE_VERSION="2.7.7"
 
 before_install:
   - sudo apt-get update -qq
 
 install:
   - pip install -U pip
-  - pip install ansible==2.6 "ansible-lint<4.0" yamllint flake8 molecule docker "pytest<3.10"
+  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible; else pip install ansible==$ANSIBLE_VERSION; fi
+  - pip install "ansible-lint<4.0" yamllint flake8 molecule docker "pytest<3.10"
   # Configure OpenShift Binary
   - sudo wget -qO- ${OC_BINARY_URL} | sudo tar -xvz -C /bin
 

--- a/molecule/default/tests/test_applier.py
+++ b/molecule/default/tests/test_applier.py
@@ -14,7 +14,7 @@ def test_oc_installed(host):
     assert oc_file.exists
     assert oc_file.user == 'root'
     assert oc_file.group == 'root'
-    assert oct(oc_file.mode) == '0755'
+    assert oct(oc_file.mode) == '0755' or oct(oc_file.mode) == '0o755'
 
 
 @pytest.mark.parametrize('name, description, display_name', [


### PR DESCRIPTION
#### What does this PR do?
This PR modifies `.travis.yml` to be able to support testing against multiple versions of Ansible. Currently I've only specified latest  and the two last major versions. We could look at supporting more / less depending on any requirements we might have.

#### How should this be tested?
Start a travis build and watch it test against each versions of ansible that we've specified on each version of python.

#### Is there a relevant Issue open for this?

requires #107 to be merged first

resolves #99

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
