### PR TITLE
Action: Patch needs to support yaml containing string values.

### DIFF
--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -20,11 +20,11 @@
         patch_path: "{{ params | check_file_location }}"
     - name: Pull data from file
       set_fact:
-        patch_content: "{{ lookup('file', params) }}"
+        patch_content: "{{ lookup('file', params) | from_yaml }}"
       when: patch_path.local_path
     - name: Pull data from url
       set_fact:
-        patch_content: "{{ lookup('url', params, split_lines=False) }}"
+        patch_content: "{{ lookup('url', params, split_lines=False) | from_yaml }}"
       when: not patch_path.local_path
   when: oc_action == 'patch'
 
@@ -35,7 +35,7 @@
        -f {{ file_facts.oc_path }} \
        {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }} \
        {% if oc_action == 'patch' %}
-         -p "{{patch_content}}"
+         -p '{{ patch_content | to_json }}'
        {% endif %}
   no_log: "{{ no_log }}"
   register: command_result

--- a/tests/files/imagestreams/python.yml
+++ b/tests/files/imagestreams/python.yml
@@ -1,0 +1,122 @@
+apiVersion: image.openshift.io/v1
+kind: ImageStream
+metadata:
+  annotations:
+    openshift.io/display-name: Python
+    openshift.io/image.dockerRepositoryCheck: 2019-02-14T06:49:49Z
+  creationTimestamp: null
+  generation: 2
+  name: python
+spec:
+  lookupPolicy:
+    local: false
+  tags:
+  - annotations:
+      description: Build and run Python 2.7 applications on RHEL 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/2.7/README.md.
+      iconClass: icon-python
+      openshift.io/display-name: Python 2.7
+      openshift.io/provider-display-name: Red Hat, Inc.
+      sampleRepo: https://github.com/openshift/django-ex.git
+      supports: python:2.7,python
+      tags: builder,python
+      version: "2.7"
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/python:2.7
+    generation: 2
+    importPolicy: {}
+    name: "2.7"
+    referencePolicy:
+      type: Local
+  - annotations:
+      description: Build and run Python 3.3 applications on RHEL 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.3/README.md.
+      iconClass: icon-python
+      openshift.io/display-name: Python 3.3
+      openshift.io/provider-display-name: Red Hat, Inc.
+      sampleRepo: https://github.com/openshift/django-ex.git
+      supports: python:3.3,python
+      tags: hidden,builder,python
+      version: "3.3"
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/python:3.3
+    generation: 2
+    importPolicy: {}
+    name: "3.3"
+    referencePolicy:
+      type: Local
+  - annotations:
+      description: Build and run Python 3.4 applications on RHEL 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.4/README.md.
+      iconClass: icon-python
+      openshift.io/display-name: Python 3.4
+      openshift.io/provider-display-name: Red Hat, Inc.
+      sampleRepo: https://github.com/openshift/django-ex.git
+      supports: python:3.4,python
+      tags: hidden,builder,python
+      version: "3.4"
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/python:3.4
+    generation: 2
+    importPolicy: {}
+    name: "3.4"
+    referencePolicy:
+      type: Local
+  - annotations:
+      description: Build and run Python 3.5 applications on RHEL 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.5/README.md.
+      iconClass: icon-python
+      openshift.io/display-name: Python 3.5
+      openshift.io/provider-display-name: Red Hat, Inc.
+      sampleRepo: https://github.com/openshift/django-ex.git
+      supports: python:3.5,python
+      tags: builder,python
+      version: "3.5"
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/python:3.5
+    generation: 2
+    importPolicy: {}
+    name: "3.5"
+    referencePolicy:
+      type: Local
+  - annotations:
+      description: Build and run Python 3.6 applications on RHEL 7. For more information
+        about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.
+      iconClass: icon-python
+      openshift.io/display-name: Python 3.6
+      openshift.io/provider-display-name: Red Hat, Inc.
+      sampleRepo: https://github.com/openshift/django-ex.git
+      supports: python:3.6,python
+      tags: builder,python
+      version: "3.6"
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/python:3.6
+    generation: 2
+    importPolicy: {}
+    name: "3.6"
+    referencePolicy:
+      type: Local
+  - annotations:
+      description: |-
+        Build and run Python applications on RHEL 7. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.6/README.md.
+
+        WARNING: By selecting this tag, your application will automatically update to use the latest version of Python available on OpenShift, including major versions updates.
+      iconClass: icon-python
+      openshift.io/display-name: Python (Latest)
+      openshift.io/provider-display-name: Red Hat, Inc.
+      sampleRepo: https://github.com/openshift/django-ex.git
+      supports: python
+      tags: builder,python
+    from:
+      kind: DockerImage
+      name: docker-registry.default.svc:5000/openshift/python:latest
+    generation: 1
+    importPolicy: {}
+    name: latest
+    referencePolicy:
+      type: Local

--- a/tests/files/patches/patch1.json
+++ b/tests/files/patches/patch1.json
@@ -1,0 +1,7 @@
+{
+  "metadata": {
+    "labels": {
+      "test": "label"
+    }
+  }
+}

--- a/tests/files/patches/python-is-patch.json
+++ b/tests/files/patches/python-is-patch.json
@@ -1,0 +1,12 @@
+{
+  "spec": {
+    "tags": [
+      {
+        "name": "2.7",
+        "importPolicy": {
+          "scheduled": true
+        }
+      }
+    ]
+  }
+}

--- a/tests/files/patches/python-is-patch.yml
+++ b/tests/files/patches/python-is-patch.yml
@@ -1,0 +1,5 @@
+spec:
+  tags:
+    - name: "2.7"
+      importPolicy:
+        scheduled: true

--- a/tests/inventories/patch/group_vars/seed-hosts.yml
+++ b/tests/inventories/patch/group_vars/seed-hosts.yml
@@ -20,3 +20,11 @@ openshift_cluster_content:
     file: "{{ inventory_dir }}/../../files/multi-files-dir/files/"
     params: "{{ inventory_dir }}/../../files/patches/patch1.yml"
     action: patch
+- object: patch containing strings
+  content:
+  - name: initialize resource
+    file: "{{ inventory_dir }}/../../files/imagestreams/python.yml"
+  - name: patch resource
+    file: "{{ inventory_dir }}/../../files/imagestreams/python.yml"
+    params: "{{ inventory_dir }}/../../files/patches/python-is-patch.yml"
+    action: patch

--- a/tests/inventories/patch/group_vars/seed-hosts.yml
+++ b/tests/inventories/patch/group_vars/seed-hosts.yml
@@ -28,3 +28,7 @@ openshift_cluster_content:
     file: "{{ inventory_dir }}/../../files/imagestreams/python.yml"
     params: "{{ inventory_dir }}/../../files/patches/python-is-patch.yml"
     action: patch
+  - name: patch resource from json
+    file: "{{ inventory_dir }}/../../files/imagestreams/python.yml"
+    params: "{{ inventory_dir }}/../../files/patches/python-is-patch.json"
+    action: patch

--- a/tests/inventories/patch/group_vars/seed-hosts.yml
+++ b/tests/inventories/patch/group_vars/seed-hosts.yml
@@ -12,6 +12,10 @@ openshift_cluster_content:
   - name: patch resource from url
     file: "{{ inventory_dir }}/../../files/multi-files-dir/files/route1.yml"
     params: "https://raw.githubusercontent.com/redhat-cop/openshift-applier/master/tests/files/patches/patch1.yml"
+  - name: patch resource from json
+    file: "{{ inventory_dir }}/../../files/multi-files-dir/files/route1.yml"
+    params: "{{ inventory_dir }}/../../files/patches/patch1.json"
+    action: patch
 - object: multi patch test
   content:
   - name: initialize resource


### PR DESCRIPTION
#### What does this PR do?
I ran into a scneario this week where our `patch` support fails to handle patch file that contain quotes strings, e.g.:

```
spec:
  tags:
    - name: "2.7"
      importPolicy:
        scheduled: true
```
This PR adds a test of this scenario, as well as a fix to the role to handle it better.

#### How should this be tested?
```
molecule test
```

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
