### PR TITLE
Add support for Jinja templates, closes #119

### DIFF
--- a/roles/openshift-applier/handlers/main.yml
+++ b/roles/openshift-applier/handlers/main.yml
@@ -13,3 +13,10 @@
     state: absent
   with_items:
     - "{{ tmp_dep_dir }}"
+
+- name: Clean up temporary Jinja directory
+  file:
+    path: "{{ item }}"
+    state: absent
+  with_items:
+    - "{{ jinja_tmp_dir.path }}"

--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -33,7 +33,7 @@
     {{ client }} {{ oc_action }} \
        {{ target_namespace }} \
        -f {{ file_facts.oc_path }} \
-       {{ (oc_action | regex_search('delete|get')) | ternary(' --ignore-not-found', '') }} \
+       {{ (oc_action | regex_search('delete')) | ternary(' --ignore-not-found', '') }} \
        {% if oc_action == 'patch' %}
          -p '{{ patch_content | to_json }}'
        {% endif %}

--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -33,7 +33,7 @@
     {{ client }} {{ oc_action }} \
        {{ target_namespace }} \
        -f {{ file_facts.oc_path }} \
-       {{ (oc_action | regex_search('delete|patch')) | ternary(' --ignore-not-found', '') }} \
+       {{ (oc_action | regex_search('delete|get')) | ternary(' --ignore-not-found', '') }} \
        {% if oc_action == 'patch' %}
          -p '{{ patch_content | to_json }}'
        {% endif %}

--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -33,7 +33,7 @@
     {{ client }} {{ oc_action }} \
        {{ target_namespace }} \
        -f {{ file_facts.oc_path }} \
-       {{ (oc_action == 'delete') | ternary(' --ignore-not-found', ' --validate=false') }} \
+       {{ (oc_action | regex_search('delete|patch')) | ternary(' --ignore-not-found', '') }} \
        {% if oc_action == 'patch' %}
          -p '{{ patch_content | to_json }}'
        {% endif %}

--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -33,7 +33,7 @@
     {{ client }} {{ oc_action }} \
        {{ target_namespace }} \
        -f {{ file_facts.oc_path }} \
-       {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }} \
+       {{ (oc_action == 'delete') | ternary(' --ignore-not-found', ' --validate=false') }} \
        {% if oc_action == 'patch' %}
          -p '{{ patch_content | to_json }}'
        {% endif %}

--- a/roles/openshift-applier/tasks/process-jinja.yml
+++ b/roles/openshift-applier/tasks/process-jinja.yml
@@ -1,0 +1,28 @@
+---
+
+- name: Delegate processing to localhost
+  block:
+  - name: Set file or template fact
+    set_fact:
+      process_file_or_template: "{{ (file != '') | ternary('file', 'template') }}"
+
+  - name: Create temporary directory for Jinja template output
+    tempfile:
+      state: directory
+    register: jinja_tmp_dir
+    notify:
+      - Clean up temporary Jinja directory
+
+  - name: Set processed Jinja template output path
+    set_fact:
+      dest_path: "{{ jinja_tmp_dir.path }}/processed_{{ lookup('vars', process_file_or_template) | basename | regex_replace('.j2$','.yml') }}"
+
+  - name: Process Jinja template
+    template:
+      src: "{{ lookup('vars', process_file_or_template) }}"
+      dest: "{{ dest_path }}"
+
+  - name: Update path
+    set_fact: {"{{ process_file_or_template }}":"{{ dest_path }}"}
+
+  delegate_to: localhost

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -36,6 +36,10 @@
   loop_control:
     loop_var: step
 
+- name: "Process Jinja Template (if applicable)"
+  include_tasks: process-jinja.yml
+  when: template | regex_search('\.j2$') or file | regex_search('\.j2$')
+
 - name: "Process Template (if applicable)"
   include_tasks: process-template.yml
   when:

--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -77,8 +77,8 @@
     {{ client }} {{ oc_action }} \
        {{ target_namespace }} \
        -f - \
-       {{ (oc_action | regex_search('delete|get')) | ternary(' --ignore-not-found', '') }} \
-       {{ (client == 'kubectl' and not (oc_action | regex_search('delete|get|patch'))) | ternary(' --validate=false', '') }}
+       {{ (oc_action | regex_search('delete')) | ternary(' --ignore-not-found', '') }} \
+       {{ (client == 'kubectl' and not (oc_action | regex_search('delete|patch'))) | ternary(' --validate=false', '') }}
   register: command_result
   no_log: "{{ no_log }}"
   failed_when:

--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -77,7 +77,8 @@
     {{ client }} {{ oc_action }} \
        {{ target_namespace }} \
        -f - \
-       {{ (oc_action == 'delete') | ternary(' --ignore-not-found', ' --validate=false') }}
+       {{ (oc_action | regex_search('delete|get')) | ternary(' --ignore-not-found', '') }} \
+       {{ (client == 'kubectl' and not (oc_action | regex_search('delete|get|patch'))) | ternary(' --validate=false', '') }}
   register: command_result
   no_log: "{{ no_log }}"
   failed_when:

--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -77,8 +77,7 @@
     {{ client }} {{ oc_action }} \
        {{ target_namespace }} \
        -f - \
-       {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }} \
-       {{ (client == 'kubectl') | ternary(' --validate=false', '') }}
+       {{ (oc_action == 'delete') | ternary(' --ignore-not-found', ' --validate=false') }}
   register: command_result
   no_log: "{{ no_log }}"
   failed_when:

--- a/tests/README.md
+++ b/tests/README.md
@@ -43,6 +43,7 @@ ansible-playbook playbooks/openshift-cluster-seed.yml -i tests/inventories/param
 ansible-playbook playbooks/openshift-cluster-seed.yml -i tests/inventories/pre-post-steps
 ansible-playbook playbooks/openshift-cluster-seed.yml -i tests/inventories/patch
 ansible-playbook playbooks/openshift-cluster-seed.yml -i tests/inventories/cluster-template
+ansible-playbook playbooks/openshift-cluster-seed.yml -i tests/inventories/jinja-templates
 ```
 
 

--- a/tests/files/jinja-templates/projectrequest_file.j2
+++ b/tests/files/jinja-templates/projectrequest_file.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: List
 items:
 {% for environment in environments %}
-- apiVersion: v1
+- apiVersion: project.openshift.io/v1
   kind: {{ 'Project' if (oc_action == 'delete') else 'ProjectRequest' }}
   metadata:
     name: {{ namespace_metadata.NAMESPACE }}-file-{{ environment }}

--- a/tests/files/jinja-templates/projectrequest_file.j2
+++ b/tests/files/jinja-templates/projectrequest_file.j2
@@ -1,0 +1,12 @@
+---
+apiVersion: v1
+kind: List
+items:
+{% for environment in environments %}
+- apiVersion: v1
+  kind: {{ 'Project' if (oc_action == 'delete') else 'ProjectRequest' }}
+  metadata:
+    name: {{ namespace_metadata.NAMESPACE }}-file-{{ environment }}
+  description: {{ namespace_metadata.NAMESPACE_DESCRIPTION }} (file) - {{ environment }}
+  displayName: {{ namespace_metadata.NAMESPACE_DISPLAY_NAME }} (file) - {{ environment }}
+{% endfor %}

--- a/tests/files/jinja-templates/projectrequest_template.j2
+++ b/tests/files/jinja-templates/projectrequest_template.j2
@@ -13,7 +13,7 @@ metadata:
   name: ${NAMESPACE}
 objects:
 {% for environment in environments %}
-- apiVersion: v1
+- apiVersion: project.openshift.io/v1
   kind: {{ 'Project' if (oc_action == 'delete') else 'ProjectRequest' }}
   metadata:
     name: ${NAMESPACE}-template-{{ environment }}

--- a/tests/files/jinja-templates/projectrequest_template.j2
+++ b/tests/files/jinja-templates/projectrequest_template.j2
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Template
+labels:
+  template: projectrequest-template
+message: |-
+  The following project/namespace has been created: ${NAMESPACE}
+metadata:
+  annotations:
+    description: |-
+      ProjectRequest Template
+  creationTimestamp: null
+  name: ${NAMESPACE}
+objects:
+{% for environment in environments %}
+- apiVersion: v1
+  kind: {{ 'Project' if (oc_action == 'delete') else 'ProjectRequest' }}
+  metadata:
+    name: ${NAMESPACE}-template-{{ environment }}
+  description: '${NAMESPACE_DESCRIPTION} (template) - {{ environment }}'
+  displayName: '${NAMESPACE_DISPLAY_NAME} (template) - {{ environment }}'
+{% endfor %}
+parameters:
+- description: Name
+  displayName: Name
+  name: NAMESPACE
+  required: true
+- description: DisplayName
+  displayName: DisplayName
+  name: NAMESPACE_DISPLAY_NAME
+  required: true
+- description: Description
+  displayName: Description
+  name: NAMESPACE_DESCRIPTION

--- a/tests/inventories/jinja-templates/group_vars/seed-hosts.yml
+++ b/tests/inventories/jinja-templates/group_vars/seed-hosts.yml
@@ -1,0 +1,29 @@
+---
+
+environments:
+  - dev
+  - test
+  - prod
+
+namespace_metadata:
+  NAMESPACE: oa-ci-jinja-templates
+  NAMESPACE_DISPLAY_NAME: OpenShift Applier Jinja Templates Test 1 (displayName)
+  NAMESPACE_DESCRIPTION: OpenShift Applier Jinja Templates Test 1 (description)
+
+openshift_cluster_content:
+- object: projectrequest
+  content:
+  - name: jinja-project-test-template
+    template: "{{ inventory_dir }}/../../files/jinja-templates/projectrequest_template.j2"
+    params_from_vars: "{{ namespace_metadata }}"
+    action: create
+  - name: jinja-project-test-file
+    file: "{{ inventory_dir }}/../../files/jinja-templates/projectrequest_file.j2"
+    action: create
+  - name: delete jinja-project-test-template
+    template: "{{ inventory_dir }}/../../files/jinja-templates/projectrequest_template.j2"
+    params_from_vars: "{{ namespace_metadata }}"
+    action: delete
+  - name: delete jinja-project-test-file
+    file: "{{ inventory_dir }}/../../files/jinja-templates/projectrequest_file.j2"
+    action: delete

--- a/tests/inventories/jinja-templates/host_vars/localhost.yml
+++ b/tests/inventories/jinja-templates/host_vars/localhost.yml
@@ -1,0 +1,3 @@
+---
+
+ansible_connection: local

--- a/tests/inventories/jinja-templates/hosts
+++ b/tests/inventories/jinja-templates/hosts
@@ -1,0 +1,3 @@
+
+[seed-hosts]
+localhost


### PR DESCRIPTION
#### What does this PR do?
Adds support for using Jinja templates

#### How should this be tested?
```
ansible-playbook playbooks/openshift-cluster-seed.yml -i tests/inventories/jinja-templates
```
This should create 6 new projects
```
$ oc get project
NAME                                  DISPLAY NAME                                                               STATUS
...
oa-ci-jinja-templates-file-dev        OpenShift Applier Jinja Templates Test 1 (displayName) (file) - dev        Active
oa-ci-jinja-templates-file-prod       OpenShift Applier Jinja Templates Test 1 (displayName) (file) - prod       Active
oa-ci-jinja-templates-file-test       OpenShift Applier Jinja Templates Test 1 (displayName) (file) - test       Active
oa-ci-jinja-templates-template-dev    OpenShift Applier Jinja Templates Test 1 (displayName) (template )- dev    Active
oa-ci-jinja-templates-template-prod   OpenShift Applier Jinja Templates Test 1 (displayName) (template )- prod   Active
oa-ci-jinja-templates-template-test   OpenShift Applier Jinja Templates Test 1 (displayName) (template )- test   Active
...
```

#### Is there a relevant Issue open for this?
#119 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
