### PR TITLE
Fixing 'openshift-applier' to allow for Ansible 2.8 runs

### DIFF
--- a/images/openshift-applier/Dockerfile
+++ b/images/openshift-applier/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:centos7
 
-ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.11.16/linux/oc.tar.gz
-ENV ANSIBLE_RPM https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.6.8-1.el7.ans.noarch.rpm
+ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.11.115/linux/oc.tar.gz
+ENV ANSIBLE_RPM https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.8.0-1.el7.ans.noarch.rpm
 ENV INSTALL_PKGS "git"
 ENV WORK_DIR /openshift-applier
 ENV HOME ${WORK_DIR}

--- a/roles/openshift-applier/tasks/main.yml
+++ b/roles/openshift-applier/tasks/main.yml
@@ -14,7 +14,6 @@
     loop_var: dependencies
   when:
     - dependencies.galaxy_requirements is defined
-  delegate_to: localhost
 
 - name: "Prepare to copy content to remote host(s) if not running 'locally'"
   import_tasks: prep-copy-inventory-to-remote.yml


### PR DESCRIPTION
#### What does this PR do?
The `delegate_to` for pulling in galaxy dependencies was causing issues with ansible 2.8. This PR fixes this issue. It also updates the `openshift-applier` container image to ansible 2.8 as well as the latest v3.11 oc client. 

#### How should this be tested?
Use the `openshift-applier` container image to run through the tests found in the `tests` directory (see README for details on execution instructions)

#### Is there a relevant Issue open for this?
N/a

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
