### PR TITLE
update testinfra module to higher so it works with 2.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
 install:
   - pip install -U pip
   - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible; else pip install ansible~=$ANSIBLE_VERSION; fi
-  - pip install "ansible-lint<4.0" yamllint flake8 molecule docker "pytest<3.10"
+  - pip install "ansible-lint<4.0" yamllint flake8 molecule docker "pytest<3.10" "testinfra==3.0.4"
   # Configure OpenShift Binary
   - sudo wget -qO- ${OC_BINARY_URL} | sudo tar -xvz -C /bin
 


### PR DESCRIPTION
#### What does this PR do?
update testinfra to >3.0.2 so that it can support ansible 2.8, more here: https://github.com/ansible/molecule/issues/1727

#### How should this be tested?
Travis build

#### Is there a relevant Issue open for this?
#125 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
