### PR TITLE
Add ability to choose between oc and kubectl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ python:
   - "2.7"
   - "3.7"
 
-cache:
-  directories:
-    - $HOME/.cache/pip
-
 env:
   global:
     - ANSIBLE_HOST_KEY_CHECKING=False
@@ -20,6 +16,10 @@ env:
   - ANSIBLE_VERSION="2.7"
   - ANSIBLE_ARGS=""
   - ANSIBLE_ARGS="-e client=kubectl"
+
+cache:
+  directories:
+    - $HOME/.cache/pip
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
     - ANSIBLE_VERSION="latest"
     - ANSIBLE_VERSION="2.6"
     - ANSIBLE_VERSION="2.7"
+    - ANSIBLE_ARGS=""
+    - ANSIBLE_ARGS="-e client=kubectl"
 
 before_install:
   - sudo apt-get update -qq
@@ -56,4 +58,4 @@ before_script:
     echo "OpenShift Cluster Running"
 
 script:
-  - molecule test
+  - molecule test ${ANSIBLE_ARGS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 python:
   - "2.7"
   - "3.7"
-
 env:
   global:
     - ANSIBLE_HOST_KEY_CHECKING=False

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - ANSIBLE_HOST_KEY_CHECKING=False
     - PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
     - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
+    - KUBE_BINARY=https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl
   matrix:
     - ANSIBLE_VERSION="latest"
     - ANSIBLE_VERSION="2.6"
@@ -28,6 +29,7 @@ install:
   - pip install "ansible-lint<4.0" yamllint flake8 molecule docker "pytest<3.10" "testinfra==3.0.4"
   # Configure OpenShift Binary
   - sudo wget -qO- ${OC_BINARY_URL} | sudo tar -xvz -C /bin
+  - curl -LO ${KUBE_BINARY} && chmod +x ./kubectl && sudo mv ./kubectl /bin/kubectl
 
 before_script:
   # Configure Docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,11 @@ env:
     - PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
     - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
     - KUBE_BINARY=https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/kubectl
-  matrix:
-    - ANSIBLE_VERSION="latest"
-    - ANSIBLE_VERSION="2.6"
-    - ANSIBLE_VERSION="2.7"
-    - ANSIBLE_ARGS=""
-    - ANSIBLE_ARGS="-e client=kubectl"
+  - ANSIBLE_VERSION="latest"
+  - ANSIBLE_VERSION="2.6"
+  - ANSIBLE_VERSION="2.7"
+  - ANSIBLE_ARGS=""
+  - ANSIBLE_ARGS="-e client=kubectl"
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - ANSIBLE_HOST_KEY_CHECKING=False
     - PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
     - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
-    - KUBE_BINARY=https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl
+    - KUBE_BINARY=https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/kubectl
   matrix:
     - ANSIBLE_VERSION="latest"
     - ANSIBLE_VERSION="2.6"

--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -8,6 +8,7 @@ Role used to apply OpenShift objects to an existing OpenShift Cluster.
 	- [Requirements](#requirements)
 	- [Role Usage](#role-usage)
 		- [Sourcing OpenShift Object Definitions](#sourcing-openshift-object-definitions)
+		- [Using oc vs kubectl](#using-oc-vs-kubectl)
 		- [Sourcing a directory with files](#sourcing-a-directory-with-files)
 		- [Ordering of Objects in the inventory](#ordering-of-objects-in-the-inventory)
 		- [Privileged Objects](#privileged-objects)
@@ -25,7 +26,7 @@ Role used to apply OpenShift objects to an existing OpenShift Cluster.
 
 ## Requirements
 
-A working OpenShift cluster that can be used to populate things like namespaces, policies and PVs (all require cluster-admin), or application level content (cluster-admin not required).
+A working OpenShift or Kubernetes cluster that can be used to populate things like namespaces, policies and PVs (all require cluster-admin), or application level content (cluster-admin not required).
 
 
 ## Role Usage
@@ -75,6 +76,25 @@ You have the choice of sourcing a `file` or a `template`. The `file` definition 
 The `tags` definition is a list of tags that will be processed if the `include_tags` variable/fact is supplied. See [Filtering content based on tags](README.md#filtering-content-based-on-tags) below for more details.
 
 The pre/post definitions are a set of pre and post roles to execute before/after a particular portion of the inventory is applied. This can be before/afterthe object levels - i.e.: before and after all of the content, or before/after certain files/templates at a content level.
+
+### Using oc vs kubectl
+
+OpenShift-Applier is compatible with both `kubectl` and `oc` as a client binary. The client can be selected by setting `client: <oc|kubectl>` in any of your vars files, or as an inline ansible argument. **Default: `client: oc`**
+
+YAML Example:
+```
+client: kubectl
+
+openshift_cluster_content:
+...
+```
+
+INLINE Argument Example:
+```
+ansible-playbook -i .applier/ playbooks/openshift-cluster-seed.yml -e client=oc
+```
+
+**NOTE: If you have `client: kubectl`, but have OpenShift Templates in your inventory (defined by .object[*].content.template), you still need to have `oc` in your PATH.**
 
 ### Sourcing a directory with files
 

--- a/roles/openshift-applier/defaults/main.yml
+++ b/roles/openshift-applier/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-client: kubectl
+client: oc
 default_oc_action: apply
 tmp_inv_dir: ''
 include_tags: ''

--- a/roles/openshift-applier/defaults/main.yml
+++ b/roles/openshift-applier/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-
+client: kubectl
 default_oc_action: apply
 tmp_inv_dir: ''
 include_tags: ''

--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -25,7 +25,7 @@
           set_fact:
             oc_ignore_unknown_parameters: false
           when:
-            - oc_version is version('3.7','<')
+            - oc_version is version('7','<')
 
       when:
         - oc_vers_check is defined

--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -10,7 +10,7 @@
         - "ansible_version.full is version('2.5','<')"
 
     - name: "Retrieve oc client version"
-      shell: oc version
+      shell: "{{client}} version"
       register: oc_vers_check
 
     # Block to handle oc command output
@@ -19,7 +19,7 @@
 
         - name: "Filter out just the oc version number"
           set_fact:
-            oc_version: "{{ (oc_vers_check.stdout | regex_search('^oc.+v([\\d.]+).*', '\\1'))[0] }}"
+            oc_version: "{{ (oc_vers_check.stdout | regex_search('^(Client.*v[\\d]\\.|oc.+v[\\d]\\.)([\\d]*).*', '\\2'))[0] }}"
 
         - name: "Do *not* use the 'ignore_unknown_parameters' flag if 'oc' version is older than 3.7"
           set_fact:

--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -30,7 +30,7 @@
 
 - name: "{{ oc_action | capitalize }} OpenShift objects based on static files for '{{ entry.object }} : {{ content.name | default(file | basename) }}'"
   command: >
-    oc {{ oc_action }} \
+    {{ client }} {{ oc_action }} \
        {{ target_namespace }} \
        -f {{ file_facts.oc_path }} \
        {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }} \

--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -74,10 +74,11 @@
        {{ (oc_param_file_item.oc_path|trim == '') | ternary('', ' --param-file="' + oc_param_file_item.oc_path + '"') }} \
        {{ oc_ignore_unknown_parameters | ternary('--ignore-unknown-parameters', '') }} \
        | \
-    oc {{ oc_action }} \
+    {{ client }} {{ oc_action }} \
        {{ target_namespace }} \
        -f - \
-       {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }}
+       {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }} \
+       {{ (client == 'kubectl') | ternary(' --validate=false', '') }}
   register: command_result
   no_log: "{{ no_log }}"
   failed_when:

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,7 @@ This area of the repo contains tests that can be run to check the `openshift-app
 - Ansible 2.5 or later
 - Operational OpenShift Cluster
 - `oc` client
+- `kubectl` client
 
 ## Molecule Considerations
 

--- a/tests/files/cluster-template/project1.yml
+++ b/tests/files/cluster-template/project1.yml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: List
 items:
 - kind: ProjectRequest
-  apiVersion: v1
+  apiVersion: project.openshift.io/v1
   metadata:
     name: oa-cluster-template-test
   displayName: OpenShift Applier Cluster Template Test 1 (displayName)


### PR DESCRIPTION
#### What does this PR do?
I've been asked a bunch lately about openshift and kubernetes are "different". As an example to show how interchangeable they can be to use, I put this little example together in applier, to basically provide the option to swap out `oc` for `kubectl`. Thought I'd open a PR in case we thought it was worth having upstream

#### How should this be tested?
Run tests.

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
