### PR TITLE
Make oc and kubectl a configurable option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,11 +10,12 @@ env:
     - PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
     - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
     - KUBE_BINARY=https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/kubectl
-  - ANSIBLE_VERSION="latest"
-  - ANSIBLE_VERSION="2.6"
-  - ANSIBLE_VERSION="2.7"
-  - ANSIBLE_ARGS=""
-  - ANSIBLE_ARGS="-e client=kubectl"
+  matrix:
+    - ANSIBLE_VERSION="latest"
+    - ANSIBLE_VERSION="2.6"
+    - ANSIBLE_VERSION="2.7"
+    - ANSIBLE_ARGS=""
+    - ANSIBLE_ARGS="-e client=kubectl"
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,6 @@ python:
   - "2.7"
   - "3.7"
 
-cache:
-  directories:
-    - $HOME/.cache/pip
-
 env:
   global:
     - ANSIBLE_HOST_KEY_CHECKING=False
@@ -20,6 +16,10 @@ env:
   - ANSIBLE_VERSION="2.7"
   - ANSIBLE_ARGS=""
   - ANSIBLE_ARGS="-e client=kubectl"
+
+cache:
+  directories:
+    - $HOME/.cache/pip
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,12 @@ env:
     - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
     - KUBE_BINARY=https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/kubectl
   matrix:
-    - ANSIBLE_VERSION="latest"
-    - ANSIBLE_VERSION="2.6"
-    - ANSIBLE_VERSION="2.7"
-    - ANSIBLE_ARGS=""
-    - ANSIBLE_ARGS="-e client=kubectl"
+    - ANSIBLE_VERSION="latest" ANSIBLE_ARGS=""
+    - ANSIBLE_VERSION="2.6"  ANSIBLE_ARGS=""
+    - ANSIBLE_VERSION="2.7" ANSIBLE_ARGS=""
+    - ANSIBLE_VERSION="latest" ANSIBLE_ARGS="-e client=kubectl"
+    - ANSIBLE_VERSION="2.6"  ANSIBLE_ARGS="-e client=kubectl"
+    - ANSIBLE_VERSION="2.7" ANSIBLE_ARGS="-e client=kubectl"
 
 cache:
   directories:
@@ -26,7 +27,7 @@ before_install:
 
 install:
   - pip install -U pip
-  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible; else pip install ansible~=$ANSIBLE_VERSION; fi
+  - if [ "$ANSIBLE_VERSION" = "latest" ]; then pip install ansible; else pip install ansible~=${ANSIBLE_VERSION}; fi
   - pip install "ansible-lint<4.0" yamllint flake8 molecule docker "pytest<3.10" "testinfra==3.0.4"
   # Configure OpenShift Binary
   - sudo wget -qO- ${OC_BINARY_URL} | sudo tar -xvz -C /bin

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ env:
     - ANSIBLE_VERSION="latest"
     - ANSIBLE_VERSION="2.6"
     - ANSIBLE_VERSION="2.7"
+    - ANSIBLE_ARGS=""
+    - ANSIBLE_ARGS="-e client=kubectl"
 
 before_install:
   - sudo apt-get update -qq
@@ -56,4 +58,4 @@ before_script:
     echo "OpenShift Cluster Running"
 
 script:
-  - molecule test
+  - molecule test ${ANSIBLE_ARGS}

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ language: python
 python:
   - "2.7"
   - "3.7"
-
 env:
   global:
     - ANSIBLE_HOST_KEY_CHECKING=False

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - ANSIBLE_HOST_KEY_CHECKING=False
     - PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
     - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
+    - KUBE_BINARY=https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl
   matrix:
     - ANSIBLE_VERSION="latest"
     - ANSIBLE_VERSION="2.6"
@@ -28,6 +29,7 @@ install:
   - pip install "ansible-lint<4.0" yamllint flake8 molecule docker "pytest<3.10" "testinfra==3.0.4"
   # Configure OpenShift Binary
   - sudo wget -qO- ${OC_BINARY_URL} | sudo tar -xvz -C /bin
+  - curl -LO ${KUBE_BINARY} && chmod +x ./kubectl && sudo mv ./kubectl /bin/kubectl
 
 before_script:
   # Configure Docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,12 +15,11 @@ env:
     - PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
     - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
     - KUBE_BINARY=https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/kubectl
-  matrix:
-    - ANSIBLE_VERSION="latest"
-    - ANSIBLE_VERSION="2.6"
-    - ANSIBLE_VERSION="2.7"
-    - ANSIBLE_ARGS=""
-    - ANSIBLE_ARGS="-e client=kubectl"
+  - ANSIBLE_VERSION="latest"
+  - ANSIBLE_VERSION="2.6"
+  - ANSIBLE_VERSION="2.7"
+  - ANSIBLE_ARGS=""
+  - ANSIBLE_ARGS="-e client=kubectl"
 
 before_install:
   - sudo apt-get update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ env:
     - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
     - KUBE_BINARY=https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/kubectl
   matrix:
-    - ANSIBLE_VERSION="latest" ANSIBLE_ARGS=""
-    - ANSIBLE_VERSION="2.6"  ANSIBLE_ARGS=""
-    - ANSIBLE_VERSION="2.7" ANSIBLE_ARGS=""
-    - ANSIBLE_VERSION="latest" ANSIBLE_ARGS="-e client=kubectl"
-    - ANSIBLE_VERSION="2.6"  ANSIBLE_ARGS="-e client=kubectl"
-    - ANSIBLE_VERSION="2.7" ANSIBLE_ARGS="-e client=kubectl"
+    - ANSIBLE_VERSION="latest" APPLIER_CLIENT="oc"
+    - ANSIBLE_VERSION="2.6"  APPLIER_CLIENT="oc"
+    - ANSIBLE_VERSION="2.7" APPLIER_CLIENT="oc"
+    - ANSIBLE_VERSION="latest" APPLIER_CLIENT="kubectl"
+    - ANSIBLE_VERSION="2.6"  APPLIER_CLIENT="kubectl"
+    - ANSIBLE_VERSION="2.7" APPLIER_CLIENT="kubectl"
 
 cache:
   directories:
@@ -58,4 +58,4 @@ before_script:
     echo "OpenShift Cluster Running"
 
 script:
-  - molecule test ${ANSIBLE_ARGS}
+  - molecule test

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
     - ANSIBLE_HOST_KEY_CHECKING=False
     - PIP_DOWNLOAD_CACHE=$HOME/.cache/pip
     - OC_BINARY_URL=https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz
-    - KUBE_BINARY=https://storage.googleapis.com/kubernetes-release/release/v1.15.0/bin/linux/amd64/kubectl
+    - KUBE_BINARY=https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/kubectl
   matrix:
     - ANSIBLE_VERSION="latest"
     - ANSIBLE_VERSION="2.6"

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -19,6 +19,7 @@ provisioner:
       all:
         use_kube_file: "${USE_KUBE_FILE:-True}"
         oc_binary_url: "${OC_BINARY_URL:-https://mirror.openshift.com/pub/openshift-v3/clients/3.10.45/linux/oc.tar.gz}"
+        kube_binary_url: "${KUBE_BINARY:-https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/kubectl}"
         oc_master_url: "${OC_MASTER_URL:-https://localhost:8443}"
         oc_username: "${OC_USERNAME:-admin}"
         oc_password: "${OC_PASSWORD:-admin}"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -8,10 +8,10 @@
         dest: "/usr/local/bin"
         remote_src: yes
     - name: Download Kubectl Binary
-      unarchive:
+      copy:
         src: "{{ kube_binary_url }}"
         dest: "/usr/local/bin"
-        remote_src: yes
+        mode: u+rx
     - name: Manage OpenShift Configuration File
       block:
         - name: Copy OpenShift Configuration File

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -8,10 +8,10 @@
         dest: "/usr/local/bin"
         remote_src: yes
     - name: Download Kubectl Binary
-      copy:
-        src: "{{ kube_binary_url }}"
+      get_url:
+        url: "{{ kube_binary_url }}"
         dest: "/usr/local/bin"
-        mode: u+rx
+        mode: '0644'
     - name: Manage OpenShift Configuration File
       block:
         - name: Copy OpenShift Configuration File

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -7,6 +7,11 @@
         src: "{{ oc_binary_url }}"
         dest: "/usr/local/bin"
         remote_src: yes
+    - name: Download Kubectl Binary
+      unarchive:
+        src: "{{ kube_binary_url }}"
+        dest: "/usr/local/bin"
+        remote_src: yes
     - name: Manage OpenShift Configuration File
       block:
         - name: Copy OpenShift Configuration File

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -11,7 +11,7 @@
       get_url:
         url: "{{ kube_binary_url }}"
         dest: "/usr/local/bin"
-        mode: '0644'
+        mode: '0744'
     - name: Manage OpenShift Configuration File
       block:
         - name: Copy OpenShift Configuration File

--- a/molecule/default/vars.yml
+++ b/molecule/default/vars.yml
@@ -2,3 +2,4 @@
 
 openshift_cluster_content: {}
 molecule_test_inventory_skip: false
+client: "{{ lookup('env', 'APPLIER_CLIENT') }}"

--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -8,6 +8,7 @@ Role used to apply OpenShift objects to an existing OpenShift Cluster.
 	- [Requirements](#requirements)
 	- [Role Usage](#role-usage)
 		- [Sourcing OpenShift Object Definitions](#sourcing-openshift-object-definitions)
+		- [Using oc vs kubectl](#using-oc-vs-kubectl)
 		- [Sourcing a directory with files](#sourcing-a-directory-with-files)
 		- [Ordering of Objects in the inventory](#ordering-of-objects-in-the-inventory)
 		- [Privileged Objects](#privileged-objects)
@@ -25,7 +26,7 @@ Role used to apply OpenShift objects to an existing OpenShift Cluster.
 
 ## Requirements
 
-A working OpenShift cluster that can be used to populate things like namespaces, policies and PVs (all require cluster-admin), or application level content (cluster-admin not required).
+A working OpenShift or Kubernetes cluster that can be used to populate things like namespaces, policies and PVs (all require cluster-admin), or application level content (cluster-admin not required).
 
 
 ## Role Usage
@@ -75,6 +76,25 @@ You have the choice of sourcing a `file` or a `template`. The `file` definition 
 The `tags` definition is a list of tags that will be processed if the `include_tags` variable/fact is supplied. See [Filtering content based on tags](README.md#filtering-content-based-on-tags) below for more details.
 
 The pre/post definitions are a set of pre and post roles to execute before/after a particular portion of the inventory is applied. This can be before/afterthe object levels - i.e.: before and after all of the content, or before/after certain files/templates at a content level.
+
+### Using oc vs kubectl
+
+OpenShift-Applier is compatible with both `kubectl` and `oc` as a client binary. The client can be selected by setting `client: <oc|kubectl>` in any of your vars files, or as an inline ansible argument. **Default: `client: oc`**
+
+YAML Example:
+```
+client: kubectl
+
+openshift_cluster_content:
+...
+```
+
+INLINE Argument Example:
+```
+ansible-playbook -i .applier/ playbooks/openshift-cluster-seed.yml -e client=oc
+```
+
+**NOTE: If you have `client: kubectl`, but have OpenShift Templates in your inventory (defined by .object[*].content.template), you still need to have `oc` in your PATH.**
 
 ### Sourcing a directory with files
 

--- a/roles/openshift-applier/defaults/main.yml
+++ b/roles/openshift-applier/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-client: kubectl
+client: oc
 default_oc_action: apply
 tmp_inv_dir: ''
 include_tags: ''

--- a/roles/openshift-applier/defaults/main.yml
+++ b/roles/openshift-applier/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-
+client: kubectl
 default_oc_action: apply
 tmp_inv_dir: ''
 include_tags: ''

--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -21,9 +21,18 @@
     # - only proceed if the oc command returned any output
     - block:
 
-        - name: "Filter out the {{ client }} version number"
+        - name: "Filter out the {{ client }} version number from yaml output"
           set_fact:
-            client_version: "{{ (client_vers_check.results[1].stdout | regex_search('^(Client.+v|oc.+v)([\\d]\\.[\\d]*).*', '\\2'))[0] }}"
+            client_version: "{{ (client_vers_check.results[0].stdout | from_yaml).clientVersion.major }}.{{ (client_vers_check.results[0].stdout | from_yaml).clientVersion.minor}}"
+          when:
+            - client_vers_check.results[0].stdout != ""
+
+        - name: "Handle cases where yaml output is not available"
+          set_fact:
+            client_version: "{{ (client_vers_check.results[1].stdout | regex_search('^oc.+v([\\d.]+).*', '\\1'))[0] }}"
+          when:
+            - client_vers_check.results[1].stdout != ""
+            - client_vers_check.results[0].stdout == ""
 
         - name: "Debug: Check {{ client }} version"
           debug:

--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -12,42 +12,34 @@
     - name: "Retrieve oc client version"
       shell: "{{ item }}"
       ignore_errors: true
-      register: oc_vers_check
+      register: client_vers_check
       with_items:
-        - oc version -o yaml
-        - oc version
+        - "{{ client }} version -o yaml"
+        - "{{ client }} version"
 
     # Block to handle oc command output
     # - only proceed if the oc command returned any output
     - block:
 
-        - name: "Filter out just the oc version number (v4.X)"
+        - name: "Filter out the {{ client }} version number"
           set_fact:
-            oc_version: "{{ (oc_vers_check.results[0].stdout | from_yaml).clientVersion.major }}.{{ (oc_vers_check.results[0].stdout | from_yaml).clientVersion.minor}}"
-          when:
-            - oc_vers_check.results[0].stdout != ""
+            client_version: "{{ (client_vers_check.results[1].stdout | regex_search('^(Client.+v|oc.+v)([\\d]\\.[\\d]*).*', '\\2'))[0] }}"
 
-        - name: "Filter out just the oc version number (v3.X)"
-          set_fact:
-            oc_version: "{{ (oc_vers_check.results[1].stdout | regex_search('^oc.+v([\\d.]+).*', '\\1'))[0] }}"
-          when:
-            - oc_vers_check.results[1].stdout != ""
-            - oc_vers_check.results[0].stdout == ""
-
-        - name: "Debug: Check oc version"
+        - name: "Debug: Check {{ client }} version"
           debug:
-            msg: "oc version is: {{ oc_version }}"
+            msg: "{{ client }} version is: {{ client_version }}"
             verbosity: 2
 
         - name: "Do *not* use the 'ignore_unknown_parameters' flag if 'oc' version is older than 3.7"
           set_fact:
-            oc_ignore_unknown_parameters: false
+            client_ignore_unknown_parameters: false
           when:
-            - oc_version is version('3.7','<')
+            - client == 'kubectl' and client_version is version('1.7','<')
+            - client == 'oc' and client_version is version('3.7','<')
 
       when:
-        - oc_vers_check is defined
-        - oc_vers_check.results[0].stdout is defined or oc_vers_check.results[1].stdout is defined
-        - oc_vers_check.results[0].stdout|trim != "" or oc_vers_check.results[1].stdout|trim != ""
+        - client_vers_check is defined
+        - client_vers_check.results[0].stdout is defined or client_vers_check.results[1].stdout is defined
+        - client_vers_check.results[0].stdout|trim != "" or client_vers_check.results[1].stdout|trim != ""
   when:
     - skip_version_checks is undefined

--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -30,7 +30,7 @@
 
 - name: "{{ oc_action | capitalize }} OpenShift objects based on static files for '{{ entry.object }} : {{ content.name | default(file | basename) }}'"
   command: >
-    oc {{ oc_action }} \
+    {{ client }} {{ oc_action }} \
        {{ target_namespace }} \
        -f {{ file_facts.oc_path }} \
        {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }} \

--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -74,10 +74,11 @@
        {{ (oc_param_file_item.oc_path|trim == '') | ternary('', ' --param-file="' + oc_param_file_item.oc_path + '"') }} \
        {{ oc_ignore_unknown_parameters | ternary('--ignore-unknown-parameters', '') }} \
        | \
-    oc {{ oc_action }} \
+    {{ client }} {{ oc_action }} \
        {{ target_namespace }} \
        -f - \
-       {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }}
+       {{ (oc_action == 'delete') | ternary(' --ignore-not-found', '') }} \
+       {{ (client == 'kubectl') | ternary(' --validate=false', '') }}
   register: command_result
   no_log: "{{ no_log }}"
   failed_when:

--- a/tests/README.md
+++ b/tests/README.md
@@ -14,6 +14,7 @@ This area of the repo contains tests that can be run to check the `openshift-app
 - Ansible 2.5 or later
 - Operational OpenShift Cluster
 - `oc` client
+- `kubectl` client
 
 ## Molecule Considerations
 

--- a/tests/files/cluster-template/project1.yml
+++ b/tests/files/cluster-template/project1.yml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: List
 items:
 - kind: ProjectRequest
-  apiVersion: v1
+  apiVersion: project.openshift.io/v1
   metadata:
     name: oa-cluster-template-test
   displayName: OpenShift Applier Cluster Template Test 1 (displayName)

--- a/tests/files/secrets/project1.yml
+++ b/tests/files/secrets/project1.yml
@@ -3,17 +3,17 @@ apiVersion: v1
 kind: List
 items:
 - kind: ProjectRequest
-  apiVersion: v1
+  apiVersion: project.openshift.io/v1
   metadata:
     name: oa-ci-secret1
   displayName: OpenShift Applier Secret Test 1 (displayName)
 - kind: ProjectRequest
-  apiVersion: v1
+  apiVersion: project.openshift.io/v1
   metadata:
     name: oa-ci-secret2
   displayName: OpenShift Applier Secret Test 2 (displayName)
 - kind: ProjectRequest
-  apiVersion: v1
+  apiVersion: project.openshift.io/v1
   metadata:
     name: oa-ci-secret3
   displayName: OpenShift Applier Secret Test 3 (displayName)

--- a/tests/files/templates/projectrequest.yml
+++ b/tests/files/templates/projectrequest.yml
@@ -12,11 +12,11 @@ metadata:
   creationTimestamp: null
   name: ${NAMESPACE}
 objects:
-- apiVersion: v1
+- apiVersion: project.openshift.io/v1
   kind: ProjectRequest
   metadata:
     name: ${NAMESPACE}
-  description: '${NAMESPACE_DESCRIPTION}' 
+  description: '${NAMESPACE_DESCRIPTION}'
   displayName: '${NAMESPACE_DISPLAY_NAME}'
 parameters:
 - description: Name


### PR DESCRIPTION
#### What does this PR do?
I've been asked a bunch lately about openshift and kubernetes are "different". As an example to show how interchangeable they can be to use, I put this little example together in applier, to basically provide the option to swap out oc for kubectl. Thought I'd open a PR in case we thought it was worth having upstream

#### How should this be tested?
Add `-e client=kubectl` to any applier command.

#### Is there a relevant Issue open for this?
n/a

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
