### PR TITLE
Update precheck to handle OCP4 cli

### DIFF
--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -17,9 +17,21 @@
     # - only proceed if the oc command returned any output
     - block:
 
-        - name: "Filter out just the oc version number"
+        - name: "Filter out just the oc version number (v3.X)"
           set_fact:
             oc_version: "{{ (oc_vers_check.stdout | regex_search('^oc.+v([\\d.]+).*', '\\1'))[0] }}"
+          when:
+            - oc_vers_check.stdout | regex_search('^oc.*')
+
+        - name: "Filter out just the oc version number (v4.X)"
+          set_fact:
+            oc_version: "{{ (oc_vers_check.stdout | regex_search('Client Version: version.Info{.*}') | regex_search('Major:\"[0-9]*\"')).split(':')[1] }}"
+          when:
+            - oc_vers_check.stdout | regex_search('^Client Version:')
+
+        - debug:
+            msg: "OC version is: {{ oc_version }}"
+            verbosity: 2
 
         - name: "Do *not* use the 'ignore_unknown_parameters' flag if 'oc' version is older than 3.7"
           set_fact:

--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -10,12 +10,12 @@
         - "ansible_version.full is version('2.5','<')"
 
     - name: "Retrieve oc client version"
-      shell: "{{ item }}" 
+      shell: "{{ item }}"
       ignore_errors: true
       register: oc_vers_check
       with_items:
-      - oc version -o yaml
-      - oc version 
+        - oc version -o yaml
+        - oc version
 
     # Block to handle oc command output
     # - only proceed if the oc command returned any output
@@ -23,15 +23,15 @@
 
         - name: "Filter out just the oc version number (v4.X)"
           set_fact:
-            oc_version: "{{ (oc_vers_check.results[0].stdout | from_yaml).clientVersion.major }}.{{ (oc_vers_check.results[0].stdout | from_yaml).clientVersion.minor}}"   
+            oc_version: "{{ (oc_vers_check.results[0].stdout | from_yaml).clientVersion.major }}.{{ (oc_vers_check.results[0].stdout | from_yaml).clientVersion.minor}}"
           when:
             - oc_vers_check.results[0].stdout != ""
 
         - name: "Filter out just the oc version number (v3.X)"
           set_fact:
             oc_version: "{{ (oc_vers_check.results[1].stdout | regex_search('^oc.+v([\\d.]+).*', '\\1'))[0] }}"
-          when: 
-          - oc_vers_check.results[1].stdout != ""
+          when:
+            - oc_vers_check.results[1].stdout != ""
           - oc_vers_check.results[0].stdout == ""
 
         - name: "Debug: Check oc version"

--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -32,7 +32,7 @@
             oc_version: "{{ (oc_vers_check.results[1].stdout | regex_search('^oc.+v([\\d.]+).*', '\\1'))[0] }}"
           when:
             - oc_vers_check.results[1].stdout != ""
-          - oc_vers_check.results[0].stdout == ""
+            - oc_vers_check.results[0].stdout == ""
 
         - name: "Debug: Check oc version"
           debug:

--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -10,27 +10,33 @@
         - "ansible_version.full is version('2.5','<')"
 
     - name: "Retrieve oc client version"
-      shell: oc version
+      shell: "{{ item }}" 
+      ignore_errors: true
       register: oc_vers_check
+      with_items:
+      - oc version -o yaml
+      - oc version 
 
     # Block to handle oc command output
     # - only proceed if the oc command returned any output
     - block:
 
-        - name: "Filter out just the oc version number (v3.X)"
-          set_fact:
-            oc_version: "{{ (oc_vers_check.stdout | regex_search('^oc.+v([\\d.]+).*', '\\1'))[0] }}"
-          when:
-            - oc_vers_check.stdout | regex_search('^oc.*')
-
         - name: "Filter out just the oc version number (v4.X)"
           set_fact:
-            oc_version: "{{ (oc_vers_check.stdout | regex_search('Client Version: version.Info{.*}') | regex_search('Major:\"[0-9]*\"')).split(':')[1] }}"
+            oc_version: "{{ (oc_vers_check.results[0].stdout | from_yaml).clientVersion.major }}.{{ (oc_vers_check.results[0].stdout | from_yaml).clientVersion.minor}}"   
           when:
-            - oc_vers_check.stdout | regex_search('^Client Version:')
+            - oc_vers_check.results[0].stdout != ""
 
-        - debug:
-            msg: "OC version is: {{ oc_version }}"
+        - name: "Filter out just the oc version number (v3.X)"
+          set_fact:
+            oc_version: "{{ (oc_vers_check.results[1].stdout | regex_search('^oc.+v([\\d.]+).*', '\\1'))[0] }}"
+          when: 
+          - oc_vers_check.results[1].stdout != ""
+          - oc_vers_check.results[0].stdout == ""
+
+        - name: "Debug: Check oc version"
+          debug:
+            msg: "oc version is: {{ oc_version }}"
             verbosity: 2
 
         - name: "Do *not* use the 'ignore_unknown_parameters' flag if 'oc' version is older than 3.7"
@@ -41,7 +47,7 @@
 
       when:
         - oc_vers_check is defined
-        - oc_vers_check.stdout is defined
-        - oc_vers_check.stdout|trim != ""
+        - oc_vers_check.results[0].stdout is defined or oc_vers_check.results[1].stdout is defined
+        - oc_vers_check.results[0].stdout|trim != "" or oc_vers_check.results[1].stdout|trim != ""
   when:
     - skip_version_checks is undefined


### PR DESCRIPTION
#### What does this PR do?
This change allows  our pre-checks to pass when using both oc (3.X) and oc (4.X) clients.

#### How should this be tested?
Take any applier inventory you would like and run it using the 3.X client and the 4.X client. You can run it with the following and there should be a debug message that will tell you what version is has picked up. Currently it is just grabbing the major version from the 4.X client. I wanted to get some feedback on the approach before continuing down the path to grab the minor version.

`ansible-playbook -I inventory playbooks/openshift-cluster-seed.yml -vv`

This feels a bit like hitting this problem over the head with a regex-hammer. But it at least allows us to move forward without having to tell it to skip any of our checks. We can likely continue to improve on this as we go (and I'd also like to open an issue upstream to see if they intend to continue following the current format or if there's anyway we can try to move them towards a more friendly structure).

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

Resolves #117 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier @pabrahamsson @oybed 