### PR TITLE
Add kube-context to Design Proposal

### DIFF
--- a/NEXTGEN_DESIGN_PROPOSAL.md
+++ b/NEXTGEN_DESIGN_PROPOSAL.md
@@ -50,6 +50,7 @@ The Dash _inventory_ will be the file where users define what contents exist and
 
 version: <2.0|3.0> # This is how we will maintain backwards compatibility. A value of '2.0' will run the current `openshift-applier`
 
+context: global-context
 namespace: global-default
 resource_groups: # This will replace `object` in openshift-applier, and serve as a logical grouping of content. This will be the level at which we pre-process all template content before putting to the api. Resource_groups should be able to be parent/child of other resource groups.
   - name: Group 1 # name fields are not required, just used for logging/debugging
@@ -58,6 +59,14 @@ resource_groups: # This will replace `object` in openshift-applier, and serve as
       - name: A Deployment
         namespace: this-deployment
         type: <manifest|helm|openshift|kustomize>
-        path:
+        template:
         params:
+# Group 1 would run a deployment to the group1-stuff namespace using the global-context kube-context and apply a template using a specific set of params
+  - name: Group 2
+    resources:
+      - name: Another Deployment
+        type: <manifest|helm|openshift|kustomize>
+        file:
+        context: a-different-kube-context
+# Group 2 would run a deployment to the global-default namespace using the a-different-kube-context kube-context and process a standard file (i.e. not a template)
 ```

--- a/NEXTGEN_DESIGN_PROPOSAL.md
+++ b/NEXTGEN_DESIGN_PROPOSAL.md
@@ -50,7 +50,7 @@ The Dash _inventory_ will be the file where users define what contents exist and
 
 version: <2.0|3.0> # This is how we will maintain backwards compatibility. A value of '2.0' will run the current `openshift-applier`
 
-context: global-context
+context: global-context #if not specified, should default to the current active context or fail right away if one is not able to be identified.
 namespace: global-default
 resource_groups: # This will replace `object` in openshift-applier, and serve as a logical grouping of content. This will be the level at which we pre-process all template content before putting to the api. Resource_groups should be able to be parent/child of other resource groups.
   - name: Group 1 # name fields are not required, just used for logging/debugging


### PR DESCRIPTION
#### What does this PR do?
Adding some thoughts on the design proposal

- We discussed wanting to be able to specify which context certain parts of the applier run with. Similar to our namespacing, I suggest we have a global default and then have the ability to specify additional contexts throughout the inventory. In cases where a global default isn't specified, we should just fallback to whatever is active

- I noticed that in the current iteration of the design proposal we have `path`. I'm assuming that we don't want to throw out the possibility of just processing some arbitrary yaml that either lives locally or somewhere out on the web. Since I'd assume that these would still take two separate paths.. we probably still want to provide the ability to specify template vs file.

#### How should this be tested?
N/A

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
