### PR TITLE
Add ability to pass custom arguments to oc/kubectl

### DIFF
--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -15,6 +15,7 @@ Role used to apply OpenShift objects to an existing OpenShift Cluster.
 		- [Privileged Objects](#privileged-objects)
 		- [Object Entries in the Inventory](#object-entries-in-the-inventory)
 		- [Override default actions with `action`](#override-default-actions-with-action)
+		- [Passing extra arguments to the client](#passing-arguments-to-the-client)
 		- [Filtering content based on tags](#filtering-content-based-on-tags)
 		- [Deprovisioning](#deprovisioning)
 		- [Dependencies](#dependencies)

--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -243,11 +243,28 @@ metadata:
     labelkey: labelvalue
 ```
 
+### Passing extra arguments to the client
+
+OpenShift Applier supports passing additional argument flags to the client (`oc` or `kubectl`). This can be done by setting `.openshift_cluster_content.object.content[*].flag` to any string value.
+
+For example, to explicitly set the patch strategy (`--type`) on a patch action:
+
+```
+- object: json merge patch
+  content:
+  - name: perform json merge patch with flag
+    file: "https://k8s.io/examples/application/deployment-patch.yaml"
+    params: "{{ inventory_dir }}/../../files/patches/patch-demo-merge.yaml"
+    action: patch
+    flags: --type merge
+```
+
+
 ### Filtering content based on tags
 
-The `openshift-applier` supports the use of tags in the inventory (see example above) to allow for filtering which content should be processed and not. The `include_tags` and `exclude_tags` variables/facts take a comma separated list of tags that will be processed. The `include_tags` will apply content **only** with the matching tags, while `exclude_tags` will apply **anything but** the content with the matching tags. 
+The `openshift-applier` supports the use of tags in the inventory (see example above) to allow for filtering which content should be processed and not. The `include_tags` and `exclude_tags` variables/facts take a comma separated list of tags that will be processed. The `include_tags` will apply content **only** with the matching tags, while `exclude_tags` will apply **anything but** the content with the matching tags.
 
-**_NOTE:_** Entries in the inventory without tags will not be processed when a valid list of tags is supplied with `include_tags`. 
+**_NOTE:_** Entries in the inventory without tags will not be processed when a valid list of tags is supplied with `include_tags`.
 
 **_NOTE:_** If the same tag exists in both `include_tags` and `exclude_tags` the run will error out. Likewise, if tags from the two options annuls each other, the execution will also error out.
 

--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -15,7 +15,7 @@ Role used to apply OpenShift objects to an existing OpenShift Cluster.
 		- [Privileged Objects](#privileged-objects)
 		- [Object Entries in the Inventory](#object-entries-in-the-inventory)
 		- [Override default actions with `action`](#override-default-actions-with-action)
-		- [Passing extra arguments to the client](#passing-arguments-to-the-client)
+		- [Passing extra arguments to the client](#passing-extra-arguments-to-the-client)
 		- [Filtering content based on tags](#filtering-content-based-on-tags)
 		- [Deprovisioning](#deprovisioning)
 		- [Dependencies](#dependencies)

--- a/roles/openshift-applier/tasks/process-file.yml
+++ b/roles/openshift-applier/tasks/process-file.yml
@@ -35,8 +35,9 @@
        -f {{ file_facts.oc_path }} \
        {{ (oc_action | regex_search('delete')) | ternary(' --ignore-not-found', '') }} \
        {% if oc_action == 'patch' %}
-         -p '{{ patch_content | to_json }}'
+         -p '{{ patch_content | to_json }}' \
        {% endif %}
+       {{ flags }}
   no_log: "{{ no_log }}"
   register: command_result
   failed_when:

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -9,6 +9,7 @@
     params: "{{ content.params | default('') }}"
     params_from_vars: "{{ content.params_from_vars | default({}) }}"
     oc_ignore_unknown_parameters: "{{ content.ignore_unknown_parameters | default(oc_ignore_unknown_parameters) }}"
+    flags: "{{ content.flags | default('') }}"
     no_log: false
 
 - name: "Set oc_action to delete when in deprovision mode"

--- a/roles/openshift-applier/tasks/process-template.yml
+++ b/roles/openshift-applier/tasks/process-template.yml
@@ -78,7 +78,8 @@
        {{ target_namespace }} \
        -f - \
        {{ (oc_action | regex_search('delete')) | ternary(' --ignore-not-found', '') }} \
-       {{ (client == 'kubectl' and not (oc_action | regex_search('delete|patch'))) | ternary(' --validate=false', '') }}
+       {{ (client == 'kubectl' and not (oc_action | regex_search('delete|patch'))) | ternary(' --validate=false', '') }} \
+       {{ flags }}
   register: command_result
   no_log: "{{ no_log }}"
   failed_when:

--- a/tests/files/patches/patch-demo-merge.yaml
+++ b/tests/files/patches/patch-demo-merge.yaml
@@ -1,0 +1,7 @@
+---
+spec:
+  template:
+    spec:
+      containers:
+      - name: patch-demo-ctr-3
+        image: gcr.io/google-samples/node-hello:1.0

--- a/tests/inventories/patch/group_vars/seed-hosts.yml
+++ b/tests/inventories/patch/group_vars/seed-hosts.yml
@@ -36,3 +36,12 @@ openshift_cluster_content:
     file: "{{ inventory_dir }}/../../files/imagestreams/python.yml"
     params: "{{ inventory_dir }}/../../files/patches/python-is-patch.json"
     action: patch
+- object: json merge patch
+  content:
+  - name: create a deployment to patch
+    file: "https://k8s.io/examples/application/deployment-patch.yaml"
+  - name: perform json merge patch with flag
+    file: "https://k8s.io/examples/application/deployment-patch.yaml"
+    params: "{{ inventory_dir }}/../../files/patches/patch-demo-merge.yaml"
+    action: patch
+    flags: --type merge


### PR DESCRIPTION
#### What does this PR do?
Introduces a "flags" option for content items, which allows passing of custom arguments to oc/kubectl.

#### How should this be tested?
Run CI... or manually run tests/inventories/patch

#### Is there a relevant Issue open for this?
resolve #149 

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
