### PR TITLE
use ubi instead of centos

### DIFF
--- a/images/openshift-applier/Dockerfile
+++ b/images/openshift-applier/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.redhat.io/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi
 
 ENV pip_packages "ansible"
 

--- a/images/openshift-applier/Dockerfile
+++ b/images/openshift-applier/Dockerfile
@@ -10,9 +10,7 @@ ENV USER_UID 1001
 
 USER root
 
-RUN yum -y --disableplugin=subscription-manager module enable httpd php:7.2;\
-    yum -y install --disableplugin=subscription-manager \
-    httpd php $INSTALL_PKGS ;\
+RUN yum -y install --disableplugin=subscription-manager $INSTALL_PKGS ;\
     curl $OC_CLIENT_MIRROR | tar -C /usr/local/bin/ -xzf - ;\
     yum --disableplugin=subscription-manager clean all ;\
     rm -rf /var/cache/yum

--- a/images/openshift-applier/Dockerfile
+++ b/images/openshift-applier/Dockerfile
@@ -1,20 +1,27 @@
-FROM centos:centos7
+FROM registry.redhat.io/ubi8/ubi
+
+ENV pip_packages "ansible"
 
 ENV OC_CLIENT_MIRROR https://mirror.openshift.com/pub/openshift-v3/clients/3.11.115/linux/oc.tar.gz
-ENV ANSIBLE_RPM https://releases.ansible.com/ansible/rpm/release/epel-7-x86_64/ansible-2.8.0-1.el7.ans.noarch.rpm
-ENV INSTALL_PKGS "git"
+ENV INSTALL_PKGS "git python3"
 ENV WORK_DIR /openshift-applier
 ENV HOME ${WORK_DIR}
 ENV USER_UID 1001
 
 USER root
 
-# Install Ansible and the 'oc' client
-RUN yum install -y $INSTALL_PKGS ;\
-    yum install -y $ANSIBLE_RPM ;\
+RUN yum -y --disableplugin=subscription-manager module enable httpd php:7.2;\
+    yum -y install --disableplugin=subscription-manager \
+    httpd php $INSTALL_PKGS ;\
     curl $OC_CLIENT_MIRROR | tar -C /usr/local/bin/ -xzf - ;\
-    yum clean all ;\
+    yum --disableplugin=subscription-manager clean all ;\
     rm -rf /var/cache/yum
+
+# Install Ansible via Pip.
+RUN pip3 install ansible
+
+RUN mkdir -p /etc/ansible
+RUN echo -e '[local]\nlocalhost ansible_connection=local' > /etc/ansible/hosts
 
 COPY . ${WORK_DIR}
 COPY images/openshift-applier/root /

--- a/images/openshift-applier/root/usr/local/bin/run
+++ b/images/openshift-applier/root/usr/local/bin/run
@@ -2,7 +2,7 @@
 DEFAULT_INV=/etc/ansible
 DEFAULT_PLAYBOOK=$HOME/playbooks/openshift-cluster-seed.yml
 
-echo "command: /usr/local/bin/ansible-playbook -i ${INVENTORY_PATH:-$DEFAULT_INV} ${PLAYBOOK:-$DEFAULT_PLAYBOOK}"
 cmd="/usr/local/bin/ansible-playbook -i ${INVENTORY_PATH:-$DEFAULT_INV} ${PLAYBOOK:-$DEFAULT_PLAYBOOK}"
+echo "command: $cmd"
 
 exec ${cmd}

--- a/images/openshift-applier/root/usr/local/bin/run
+++ b/images/openshift-applier/root/usr/local/bin/run
@@ -1,7 +1,8 @@
 #!/bin/bash
-DEFAULT_INV=$HOME/test/inventory
+DEFAULT_INV=/etc/ansible
 DEFAULT_PLAYBOOK=$HOME/playbooks/openshift-cluster-seed.yml
 
-cmd="/usr/bin/ansible-playbook -i ${INVENTORY_PATH:-$DEFAULT_INV} ${PLAYBOOK:-$DEFAULT_PLAYBOOK}"
+echo "command: /usr/local/bin/ansible-playbook -i ${INVENTORY_PATH:-$DEFAULT_INV} ${PLAYBOOK:-$DEFAULT_PLAYBOOK}"
+cmd="/usr/local/bin/ansible-playbook -i ${INVENTORY_PATH:-$DEFAULT_INV} ${PLAYBOOK:-$DEFAULT_PLAYBOOK}"
 
 exec ${cmd}


### PR DESCRIPTION
#### What does this PR do?
Changes the base image from centos to the ubi. Changes the default inventory that was missing.

#### How should this be tested?
build the new image
```
docker build -t redhat-cop/openshift-applier -f images/openshift-applier/Dockerfile .
```

use the new image

```
docker run -u $(id -u)   -v $HOME/.kube/config:/openshift-applier/.kube/config:z -t redhat-cop/openshift-applier
```
or as an example something like 

```
docker run -u $(id -u) -v $HOME/.kube/config:/openshift-applier/.kube/config:z -v /Users/mcanoy/labs/sonarqube-auth-openshift/example/:/tmp/sonarqube-inventory -e INVENTORY_PATH=/tmp/sonarqube-inventory/inventory -e PLAYBOOK=/tmp/sonarqube-inventory/apply.yml  -t redhat-cop/openshift-applier/labs/sonarqube-auth-openshift/example/:/tmp/sonarqube-inventory -e INVENTORY_PATH=/etc/ansible/hosts  -t redhat-cop/openshift-applier
```

#### Is there a relevant Issue open for this?
not that I'm aware of.

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
