### PR TITLE
Add wait for object role

### DIFF
--- a/roles/wait-for-object/README.md
+++ b/roles/wait-for-object/README.md
@@ -1,0 +1,35 @@
+# Wait-for-resource
+
+## What does this role do?
+
+This role allows you to specify a serious of variables and waits until it is able to see these resources available within a cluster.
+
+## Variables
+- k8s_object:
+- k8s_object_name:
+- k8s_object_namespace:
+- k8s_object_wait_seconds:
+
+
+## Parameters
+
+| Name      | Description   | Required | Default |
+| ----------- | ----------- | -------- | ------- |
+| k8s_object | The type of k8s object that you're waiting on (pod, configmap, etc.) | Y | N/A |
+| k8s_object_name | The name of the k8s object that you're waiting on. Will look for all objects of a type if no name is specified | N | N/A |
+| k8s_object_namespace | The namespace of the k8s object that you're waiting on. Will look for all objects in all namespaces if no namespace is specified | N | N/A |
+| k8s_object_wait_seconds | The number of "warm-up" seconds to give an object before checking for its existance. | N | 0 |
+
+## Example
+
+```yaml
+- hosts: my-test-hosts 
+  tasks:
+  - name: Check for a configmap
+    include_role:
+      name: roles/wait-for-object
+    vars:
+      k8s_object: configmap
+      k8s_object_name: ldap-config
+      k8s_object_namespace: cluster-ops
+```

--- a/roles/wait-for-object/defaults/main.yml
+++ b/roles/wait-for-object/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-k8s_object_labels: [] 
+k8s_object_labels: []
 k8s_object_name: ''
 k8s_object_namespace: ''

--- a/roles/wait-for-object/defaults/main.yml
+++ b/roles/wait-for-object/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+k8s_object_labels: [] 
+k8s_object_name: ''
+k8s_object_namespace: ''

--- a/roles/wait-for-object/tasks/main.yml
+++ b/roles/wait-for-object/tasks/main.yml
@@ -4,12 +4,12 @@
     msg: "ERROR: {{ k8s_object }} is not defined."
   when: k8s_object is not defined or k8s_object == ""
 
-- fail:
-    msg: "ERROR: {{ k8s_object_name }} is not defined."
+- debug:
+    msg: "{{ k8s_object_name }} is not defined. Will search all {{ k8s_object }}'s."
   when: k8s_object_name is not defined or k8s_object_name == ""
 
 - debug:
-    msg: "ERROR: {{ k8s_object_namespace }} is not defined."
+    msg: "{{ k8s_object_namespace }} is not defined. Will search all projects on cluster."
   when: k8s_object_namespace is not defined or k8s_object_namespace == ""
 
 - name: "Allow warm up period if necessary"
@@ -21,7 +21,9 @@
     kind: "{{ k8s_object }}"
     name: "{{ k8s_object_name }}"
     namespace: "{{ k8s_object_namespace | default('') }}"
-  retries: "{{ retry_count | default(10) }}"
+    label_selectors: "{{ k8s_object_labels }}"
+  retries: "{{ k8s_object_retry_count | default(10) }}"
+  delay: "{{ k8s_object_retry_delay | default(10) }}"
   ignore_errors: yes
   register: k8s_return
 

--- a/roles/wait-for-object/tasks/main.yml
+++ b/roles/wait-for-object/tasks/main.yml
@@ -1,0 +1,37 @@
+---
+
+- fail:
+    msg: "ERROR: {{ k8s_object }} is not defined."
+  when: k8s_object is not defined or k8s_object == ""
+
+- fail:
+    msg: "ERROR: {{ k8s_object_name }} is not defined."
+  when: k8s_object_name is not defined or k8s_object_name == ""
+
+- debug:
+    msg: "ERROR: {{ k8s_object_namespace }} is not defined."
+  when: k8s_object_namespace is not defined or k8s_object_namespace == ""
+
+- name: "Allow warm up period if necessary"
+  pause:
+    seconds: "{{ k8s_object_wait_secs | default(0) }}"
+
+- name: "Wait until {{ k8s_object }} {{ k8s_object_name }} is available in namespace {{ k8s_object_namespace }}"
+  k8s_facts:
+    kind: "{{ k8s_object }}"
+    name: "{{ k8s_object_name }}"
+    namespace: "{{ k8s_object_namespace | default('') }}"
+  retries: "{{ retry_count | default(10) }}"
+  ignore_errors: yes
+  register: k8s_return
+
+- name: "Alert {{ k8s_object }} {{ k8s_object_name }} is unavailable in namespace {{ k8s_object_namespace }}"
+  fail:
+    msg: "{{ k8s_object }} {{ k8s_object_name }} is unavailable in namespace {{ k8s_object_namespace }}"
+  when: k8s_return.resources is not defined
+
+- name: "DEBUG: Returning object definition"
+  debug:
+    msg: "{{ k8s_return.resources }}"
+    verbosity: 1
+  when: k8s_return.resources is defined


### PR DESCRIPTION
#### What does this PR do?
This PR adds a role that checks for a specific object to be in place in a cluster

#### How should this be tested?
This can be tested with the example found in the README:
```
```yaml
- hosts: my-test-hosts
  tasks:
  - name: Check for my configmap
    include_role:
      name: roles/wait-for-object
    vars:
      k8s_object: configmap
      k8s_object_name: ldap-config
      k8s_object_namespace: cluster-ops
```
The values for the variables can be switched out for something that exists in your cluster.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
