### PR TITLE
fix typo in example option flag

### DIFF
--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -301,7 +301,7 @@ For roles that requires input parameters, the implementation also supports suppl
 
 ### Deprovisioning
 
-The `openshift-applier` role also supports global deprovisioning of resources. This can be done either using `provision: false`. Setting `-e provision: false` on a run essentially acts like a big 'undo' button, re-running all files and templates through `oc delete -f <resources>`. This can be useful when you want to do a full cleanup to ensure the integrity of you IaC repo, or for simple cleanup while testing changes.
+The `openshift-applier` role also supports global deprovisioning of resources. This can be done either using `provision: false`. Setting `-e provision=false` on a run essentially acts like a big 'undo' button, re-running all files and templates through `oc delete -f <resources>`. This can be useful when you want to do a full cleanup to ensure the integrity of you IaC repo, or for simple cleanup while testing changes.
 
 ### Dependencies
 


### PR DESCRIPTION
#### What does this PR do?
The example usage `-e provision: false` did not work for me.  Instead, changing it to `-e provision=false` worked.

#### How should this be tested?
This command didn't work `ansible-playbook site.yml --ask-vault-pass -e provision: false`
Whereas, this command worked: `ansible-playbook site.yml --ask-vault-pass -e provision=false`

#### Is there a relevant Issue open for this?
I didn't do much research.

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
