### PR TITLE
Additional Helm functionality and improvements

### DIFF
--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -74,7 +74,7 @@ openshift_cluster_content:
 - object: <object_type>
   content:
   - name: <definition_name>
-    helm
+    helm:
       name: <helm chart name>  # Required
       chart: <helm chart source> # Required
       version: <chart version to use> # Optional

--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -74,10 +74,25 @@ openshift_cluster_content:
 - object: <object_type>
   content:
   - name: <definition_name>
-    helm_chart: <helm_chart_source>
-    helm_values:
-      KEY: Value # Optional: can only be done as key value pairs, collections and lists will not work
-    helm_values_file: <helm_values_file_source> # Optional: Defaults to use chart's values.yaml
+    helm
+      name: <helm chart name>  # Required
+      chart: <helm chart source> # Required
+      version: <chart version to use> # Optional
+      namespace: <namespace scope> # Optional 
+      repos: # Optional
+      - name: repo1
+        url: https://repo1.helm/...
+      - name: repo2
+        url: https://repo2.helm/...
+      set_param: # Optional: List of "--set " parameters. Defaults to use chart's values.
+      - 'key1=value1'
+      - 'key2=value2'
+      values_param: # Optional: List of files/URLs to values files. Defaults to use chart's values.
+      - <local file1>
+      - <url1>
+      - <local file2>
+      - <url2>
+      flags: '' # Optiona: String with additional flags to pass to the helm command
     action: <apply|create> # Optional: Defaults to 'apply'
     namespace: <target_openshift_namespace>
 ```

--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -142,14 +142,17 @@ Additional examples are available in the [test directory](https://github.com/red
 
 **NOTE: In order to use the jinja processing engine the file suffix must be '.j2'**
 
-Helm charts use their own `helm_chart` to source the chart into a `helm template` command. It will use the default `values.yaml` file. To override `helm_values_file` can be used, or `helm_values` for inline variables. `helm_flags` can also be used for any additional flags you wish to pass to helm.
+Helm charts use a `helm` dictionary to source the chart into a `helm template` command. It will use the default `values.yaml` file, but various overrides exists to feed custom values to the charts. The complete list of supported parameters is above, but the values file can be substituted by supplying one or more files (or URLS) with the `values_param`, and the `set_param` can be used to inject individual values during the processing of the charts.
 ```yaml
 openshift_cluster_content:
 - object:
   content:
   - name: Apply a Helm Chart
-    helm_chart: "{{ inventory_dir }}/../../helm-charts/test-chart/"
-    helm_values_file: "{{ inventory_dir }}/../../helm-charts/test-chart/values-test.yaml"
+    helm:
+      name: Test Chart
+      chart: "{{ inventory_dir }}/../../helm-charts/test-chart/"
+      values_param:
+        - "{{ inventory_dir }}/../../helm-charts/test-chart/values-test.yaml"
 ```    
 Additional examples are available in the [helm charts test directory](https://github.com/redhat-cop/openshift-applier/tree/master/tests/files/helm-charts)
 

--- a/roles/openshift-applier/tasks/process-helm.yml
+++ b/roles/openshift-applier/tasks/process-helm.yml
@@ -36,7 +36,14 @@
        {{ helm_namespace_option }} \
        {{ helm_set_option }} \
        {{ helm_values_option }} \
-       {{ helm.flags|d('') }} > /tmp/output.yml 
+       {{ helm.flags|d('') }} \
+       | \
+    {{ client }} {{ oc_action }} \
+       {{ target_namespace }} \
+       -f - \
+       {{ (oc_action | regex_search('delete')) | ternary(' --ignore-not-found', '') }} \
+       {{ (client == 'kubectl' and not (oc_action | regex_search('delete|patch'))) | ternary(' --validate=false', '') }} \
+       {{ flags }}
   register: command_result
   no_log: "{{ no_log }}"
   failed_when:

--- a/roles/openshift-applier/tasks/process-helm.yml
+++ b/roles/openshift-applier/tasks/process-helm.yml
@@ -36,14 +36,7 @@
        {{ helm_namespace_option }} \
        {{ helm_set_option }} \
        {{ helm_values_option }} \
-       {{ helm.flags|d('') }} \
-       | \
-    {{ client }} {{ oc_action }} \
-       {{ target_namespace }} \
-       -f - \
-       {{ (oc_action | regex_search('delete')) | ternary(' --ignore-not-found', '') }} \
-       {{ (client == 'kubectl' and not (oc_action | regex_search('delete|patch'))) | ternary(' --validate=false', '') }} \
-       {{ flags }}
+       {{ helm.flags|d('') }} > /tmp/output.yml 
   register: command_result
   no_log: "{{ no_log }}"
   failed_when:

--- a/roles/openshift-applier/tasks/process-helm.yml
+++ b/roles/openshift-applier/tasks/process-helm.yml
@@ -3,55 +3,40 @@
 - name: "Reset Command Line Options"
   set_fact:
     helm_set_option: ''
+    helm_values_option: ''
+    helm_version_option: "{{ (helm.version|d('')|trim == '') | ternary('', ' --version \"' + helm.version|d('') + '\"') }}"
+    helm_namespace_option: "{{ (helm.namespace|d('')|trim == '') | ternary('', ' --namespace \"' + helm.namespace|d('') + '\"') }}"
 
-- name: "Pre-process helm chart (if applicable)"
+- name: "Add helm repo(s) to be used (if applicable)"
   block:
-    - name: "Check whether helm folder exists"
-      stat:
-        path: "{{ helm_chart }}"
-      ignore_errors: true
-      register: helm_chart_result
-      delegate_to: localhost
-    - name: "Fail when helm folder does not exist"
-      fail:
-        msg: "{{ helm_chart }} - Helm Chart is not a directory"
-      when:
-        - helm_chart_result.stat.isdir == False
+    - shell: >
+        helm repo add "{{ item.name }}" "{{ item.url }}"
+      loop: "{{ helm.repos }}"
+    - shell: >
+        helm repo update
   when:
-    - helm_chart|trim != ''
+    - helm.repos is defined
+    - helm.repos|length > 0
 
-- name: "Pre-process helm values (if applicable)"
-  block:
-    - name: "Check whether helm values file exists"
-      stat:
-        path: "{{ helm_values_file }}"
-      ignore_errors: true
-      register: helm_values_file_result
-      delegate_to: localhost
-    - name: "Fail when helm values file does not exist"
-      fail:
-        msg: "{{ helm_values_file }} - Helm values file doesn't exist."
-      when:
-        - helm_values_file_result.stat.exists == False
-  when:
-    - helm_values_file|trim != ''
+- name: "Change 'helm.set_param' fact into command line parameters (if applicable)"
+  set_fact:
+    helm_set_option: "{{ helm_set_option }} --set '{{ item }}'"
+  loop: "{{ helm.set_param | default([]) }}"
 
-# CAN'T DO COLLECTIONS, SO BLOCKED: https://github.com/helm/helm/issues/5618
-# WORKAROUND: https://github.com/helm/helm/issues/1987#issuecomment-324341396
-# will need to be output and iterated through in either dot format for every single value in mapping
-# IF LIST will also need to use an index for every single value
-# - name: "Change 'helm_values' fact (if applicable) into command line parameters"
-#   set_fact:
-#     helm_set_option: "{{ helm_set_option }} --set='{{ item.key }}={{ item.value }}'"
-#   with_dict: "{{ helm_values }}"
+- name: "Change 'helm.values_param' fact into command line parameters (if applicable)"
+  set_fact:
+    helm_values_option: "{{ helm_values_option }} --values '{{ item }}'"
+  loop: "{{ helm.values_param | default([]) }}"
 
-- name: "{{ oc_action | capitalize }} OpenShift objects based on helm template for '{{ entry.object }} : {{ content.name | default(helm | basename) }}'"
+- name: "{{ oc_action | capitalize }} OpenShift objects based on helm template for '{{ entry.object }} : {{ content.name | default(helm.name) }}'"
   shell: >
     helm template \
-       {{ helm_chart }} \
+       {{ helm.name }} {{ helm.chart }} \
+       {{ helm_version_option }} \
+       {{ helm_namespace_option }} \
        {{ helm_set_option }} \
-       {{ (helm_values_file|trim == '') | ternary('', ' -f="' + helm_values_file + '"') }} \
-       {{ helm_flags }} \
+       {{ helm_values_option }} \
+       {{ helm.flags|d('') }} \
        | \
     {{ client }} {{ oc_action }} \
        {{ target_namespace }} \

--- a/roles/openshift-applier/tasks/process-one-entry.yml
+++ b/roles/openshift-applier/tasks/process-one-entry.yml
@@ -4,12 +4,9 @@
   set_fact:
     target_namespace: ''
     oc_action: "{{ content.action | default(default_oc_action) }}"
-    helm_chart: "{{ content.helm_chart | default('') }}"
-    helm_values: "{{ content.helm_values | default({}) }}"
-    helm_values_file: "{{ content.helm_values_file | default('') }}"
-    helm_flags: "{{ content.helm_flags | default('') }}"
     file: "{{ content.file | default('') }}"
     template: "{{ content.template | default('') }}"
+    helm: "{{ content.helm | default({}) }}"
     kustomize: "{{ content.kustomize | default('') }}"
     params: "{{ content.params | default('') }}"
     params_from_vars: "{{ content.params_from_vars | default({}) }}"
@@ -60,7 +57,9 @@
 - name: "Process Helm chart (if applicable)"
   include_tasks: process-helm.yml
   when:
-    - helm_chart|trim != ''
+    - helm.keys()|length > 0
+    - helm.name|d('')|trim != ''
+    - helm.chart|d('')|trim != ''
 
 - name: "Process Kustomize (if applicable)"
   include_tasks: process-kustomize.yml

--- a/tests/inventories/helm-charts/group_vars/seed-hosts.yml
+++ b/tests/inventories/helm-charts/group_vars/seed-hosts.yml
@@ -35,31 +35,15 @@ openshift_cluster_content:
       chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
       values_param:
         - "{{ inventory_dir }}/../../files/helm-charts/test-chart/values-test.yaml"
-
-- object: helm-repos
-  content:
   - name: helm-project-test-remote-repo
     helm:
       name: "test-chart-4"
       chart: "bitnami/mysql"
-      namespace: "{{ namespace_metadata.NAMESPACE }}-2"
       repos:
         - name: bitnami
           url: https://charts.bitnami.com/bitnami
       set_param:
         - 'auth.rootPassword=admin12345'
-
-- object: clean-up
-  content:
-  - name: helm-project-test-remote-repo
-    helm:
-      name: "test-chart-4"
-      chart: "bitnami/mysql"
-      namespace: "{{ namespace_metadata.NAMESPACE }}-2" 
-      repos:
-        - name: bitnami
-          url: https://charts.bitnami.com/bitnami
-    action: delete
 
   - name: delete helm-project-test-template
     helm:
@@ -84,3 +68,14 @@ openshift_cluster_content:
       values_param:
         - "{{ inventory_dir }}/../../files/helm-charts/test-chart/values-test-delete.yaml"
     action: delete
+  - name: helm-project-test-remote-repo
+    helm:
+      name: "test-chart-4"
+      chart: "bitnami/mysql"
+      repos:
+        - name: bitnami
+          url: https://charts.bitnami.com/bitnami
+      set_param:
+        - 'namespace.delete=true'
+    action: delete
+

--- a/tests/inventories/helm-charts/group_vars/seed-hosts.yml
+++ b/tests/inventories/helm-charts/group_vars/seed-hosts.yml
@@ -4,47 +4,83 @@ environments:
 - dev
 - test
 - prod
+
 namespace_metadata:
   NAMESPACE: oa-ci-helm-charts
   NAMESPACE_DISPLAY_NAME: OpenShift Applier Helm Charts Test 1 (displayName)
   NAMESPACE_DESCRIPTION: OpenShift Applier Helm Charts Test 1 (description)
+
 openshift_applier_raw: "https://raw.githubusercontent.com/redhat-cop/openshift-applier"
-openshift_applier_ver: master
+openshift_applier_ver: main
 
 openshift_cluster_content:
 - object: projectrequest
   content:
   - name: helm-project-test-chart
-    helm_chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
+    helm:
+      name: "test-chart-1"
+      chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
     action: create
-  # BLOCKED: https://github.com/helm/helm/issues/5618
-  # WORKAROUND: https://github.com/helm/helm/issues/1987#issuecomment-324341396
-  #  - name: helm-project-test-chart-with-values
-  #    helm_chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
-  #    helm_values:
-  #      namespace:
-  #        name: "{{ namespace_metadata.NAMESPACE }}-2"
-  #        description: "{{ namespace_metadata.NAMESPACE_DISPLAY_NAME }}"
-  #        display_name: "{{ namespace_metadata.NAMESPACE_DESCRIPTION }}"
+  - name: helm-project-test-chart-with-values
+    helm:
+      name: "test-chart-2"
+      chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
+      set_param:
+        - "namespace.name={{ namespace_metadata.NAMESPACE }}-2"
+        - "namespace.description={{ namespace_metadata.NAMESPACE_DISPLAY_NAME }}"
+        - "namespace.display_name={{ namespace_metadata.NAMESPACE_DESCRIPTION }}"
   - name: helm-project-test-file-with-values
-    helm_chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
-    helm_values_file: "{{ inventory_dir }}/../../files/helm-charts/test-chart/values-test.yaml"
-  - name: delete helm-project-test-template
-    helm_chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
-    helm_flags: "--set namespace.delete=true"
+    helm:
+      name: "test-chart-3"
+      chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
+      values_param:
+        - "{{ inventory_dir }}/../../files/helm-charts/test-chart/values-test.yaml"
+
+- object: helm-repos
+  content:
+  - name: helm-project-test-remote-repo
+    helm:
+      name: "test-chart-4"
+      chart: "bitnami/mysql"
+      namespace: "{{ namespace_metadata.NAMESPACE }}-2"
+      repos:
+        - name: bitnami
+          url: https://charts.bitnami.com/bitnami
+      set_param:
+        - 'auth.rootPassword=admin12345'
+
+- object: clean-up
+  content:
+  - name: helm-project-test-remote-repo
+    helm:
+      name: "test-chart-4"
+      chart: "bitnami/mysql"
+      namespace: "{{ namespace_metadata.NAMESPACE }}-2" 
+      repos:
+        - name: bitnami
+          url: https://charts.bitnami.com/bitnami
     action: delete
-  # BLOCKED: https://github.com/helm/helm/issues/5618
-  # WORKAROUND: https://github.com/helm/helm/issues/1987#issuecomment-324341396
-  #  - name: delete helm-project-test-file-with-values
-  #    helm_chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
-  #    helm_values:
-  #      namespace:
-  #        name: "{{ namespace_metadata.NAMESPACE }}-1"
-  #        description: "{{ namespace_metadata.NAMESPACE_DISPLAY_NAME }}"
-  #        display_name: "{{ namespace_metadata.NAMESPACE_DESCRIPTION }}"
-  #        delete: true
-  #    action: delete
+
+  - name: delete helm-project-test-template
+    helm:
+      name: "test-chart-1"
+      chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
+      flags: "--set namespace.delete=true"
+    action: delete
+  - name: delete helm-project-test-file-with-values
+    helm:
+      name: "test-chart-2"
+      chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
+      set_param:
+        - "namespace.name={{ namespace_metadata.NAMESPACE }}-2"
+        - "namespace.description={{ namespace_metadata.NAMESPACE_DISPLAY_NAME }}"
+        - "namespace.display_name={{ namespace_metadata.NAMESPACE_DESCRIPTION }}"
+        - "namespace.delete=true"
+    action: delete
   - name: delete helm-project-test-file-with-values-file
-    helm_chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
-    helm_values_file: "{{ inventory_dir }}/../../files/helm-charts/test-chart/values-test-delete.yaml"
+    helm:
+      name: "test-chart-3"
+      chart: "{{ inventory_dir }}/../../files/helm-charts/test-chart/"
+      values_param:
+        - "{{ inventory_dir }}/../../files/helm-charts/test-chart/values-test-delete.yaml"
     action: delete

--- a/tests/inventories/jinja-templates/group_vars/seed-hosts.yml
+++ b/tests/inventories/jinja-templates/group_vars/seed-hosts.yml
@@ -9,7 +9,7 @@ namespace_metadata:
   NAMESPACE_DISPLAY_NAME: OpenShift Applier Jinja Templates Test 1 (displayName)
   NAMESPACE_DESCRIPTION: OpenShift Applier Jinja Templates Test 1 (description)
 openshift_applier_raw: "https://raw.githubusercontent.com/redhat-cop/openshift-applier"
-openshift_applier_ver: master
+openshift_applier_ver: main
 
 openshift_cluster_content:
 - object: projectrequest

--- a/tests/inventories/kustomize/group_vars/seed-hosts.yml
+++ b/tests/inventories/kustomize/group_vars/seed-hosts.yml
@@ -7,7 +7,7 @@ namespace_metadata:
   NAMESPACE_DISPLAY_NAME: OpenShift Applier Kustomize Test 1 (displayName)
   NAMESPACE_DESCRIPTION: OpenShift Applier Kustomize Test 1 (description)
 openshift_applier_raw: "https://raw.githubusercontent.com/redhat-cop/openshift-applier"
-openshift_applier_ver: master
+openshift_applier_ver: main
 
 openshift_cluster_content:
 - object: projectrequest

--- a/tests/inventories/patch/group_vars/seed-hosts.yml
+++ b/tests/inventories/patch/group_vars/seed-hosts.yml
@@ -11,7 +11,7 @@ openshift_cluster_content:
     action: patch
   - name: patch resource from url
     file: "{{ inventory_dir }}/../../files/multi-files-dir/files/route1.yml"
-    params: "https://raw.githubusercontent.com/redhat-cop/openshift-applier/master/tests/files/patches/patch1.yml"
+    params: "https://raw.githubusercontent.com/redhat-cop/openshift-applier/main/tests/files/patches/patch1.yml"
   - name: patch resource from json
     file: "{{ inventory_dir }}/../../files/multi-files-dir/files/route1.yml"
     params: "{{ inventory_dir }}/../../files/patches/patch1.json"


### PR DESCRIPTION
#### What does this PR do?
This prepares the "helm support" for next phase to allow for additional functionality, such as "helm upgrade".

This PR also introduces the use of Helm repos to allow for content to be installed from available online repos. With this, the chart can be either a local directory or a remote URL. 

#### How should this be tested?
Use the test cases in this repo, or create your own inventory with desirable Helm charts - local and/or remote.

**Example:**

The following inventory would allow you to deploy JetStack's cert-manager chart:
_(**Note** that it's expected that the namespace (cert-mgmt) already exists, or is created by another part of the inventory above)_

```
openshift_cluster_content:
  : 
  : 
- object: Helm Repos
  content:
  - name: Certificate Management
    helm:
      name: "cert-manager"
      chart: "jetstack/cert-manager"
      version: "v1.6.1"
      namespace: "cert-mgmt"
      repos:
        - name: jetstack
          url: https://charts.jetstack.io
      set_param:
        - 'installCRDs=true'
        - 'extraArgs={--dns01-recursive-nameservers=8.8.8.8:53\,1.1.1.1:53,--dns01-recursive-nameservers-only}'
```


#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier @jfilipcz @makirill 
