### PR TITLE
Fix a pre-check condition for Helm binary 

### DIFF
--- a/roles/openshift-applier/tasks/pre-check.yml
+++ b/roles/openshift-applier/tasks/pre-check.yml
@@ -55,7 +55,7 @@
       ignore_errors: true
       register: helm_version_check
       when:
-        - openshift_cluster_content | join(', ') | regex_search('helm_chart')
+        - openshift_cluster_content | join(', ') | regex_search('helm')
 
     # Block to handle helm command output
     # - only proceed if the helm command returned any output


### PR DESCRIPTION

#### What does this PR do?
Due to changes in helm openshift_cluster_content made on V3.0.0 (helm_chart -> helm), pre-check condition for helm binary version would not be triggered. This PR fixes that.

#### How should this be tested?
Check if helm version is checked when openshift_cluster_content has a helm definition.

#### Is there a relevant Issue open for this?
Provide a link to any open issues that describe the problem you are solving.

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
