### PR TITLE
Adding support for a new variable named "galaxy_sources"

### DIFF
--- a/roles/openshift-applier/README.md
+++ b/roles/openshift-applier/README.md
@@ -43,6 +43,11 @@ The variable definitions come in the form of an object, `openshift_cluster_conte
 openshift_cluster_content:
 - galaxy_requirements: # Optional: only needed if pre/post steps are specified below
     - "path/to/galaxy/requirements.yml" # Has to be a local file - e.g: with the inventory
+- galaxy_sources:      # Optional: only needed if pre/post steps are specified below
+    - src: https://github.com/....
+      version: v1.0.0
+    - src: https://github.com/....
+      version: main
 - object: <object_type>
   pre_steps: # Optional: pre-steps at object level can be added if desired
     - role: <path to an ansible role>
@@ -346,7 +351,7 @@ The `openshift-applier` supports the use of pre and post steps to allow for task
 
 The pre/post steps can be added at both the `object` level as well as the `content level`. See example at the top for more details.
 
-In essence, the pre/post steps are ansible roles that gets executed in the order they are found in the inventory. These roles are sourced from the `galaxy_requirements` file part of the inventory. See the official [Ansible Galaxy docs for more details on the requirements yaml file](http://docs.ansible.com/ansible/latest/galaxy.html#installing-multiple-roles-from-a-file).
+In essence, the pre/post steps are ansible roles that gets executed in the order they are found in the inventory. These roles are sourced from the `galaxy_sources` list, or `galaxy_requirements` file, part of the inventory. See the official [Ansible Galaxy docs for more details on the requirements yaml file](http://docs.ansible.com/ansible/latest/galaxy.html#installing-multiple-roles-from-a-file).
 
 **_NOTE:_** it is important that the repos used for pre/post roles have the `meta/main.yml` file setup correctly. See the [Ansible Galaxy docs](http://docs.ansible.com/ansible/latest/galaxy.html) for more details.
 

--- a/roles/openshift-applier/tasks/install-dependencies.yml
+++ b/roles/openshift-applier/tasks/install-dependencies.yml
@@ -39,7 +39,7 @@
   command: >
     ansible-galaxy install -r "{{ item }}" -p "{{ tmp_dep_dir }}"
   with_items:
-    - "{{ dependencies.galaxy_requirements }}"
+    - "{{ galaxy_requirements }}"
 
 - name: "Clean-up temporary file from above - if needed"
   file:

--- a/roles/openshift-applier/tasks/install-dependencies.yml
+++ b/roles/openshift-applier/tasks/install-dependencies.yml
@@ -15,6 +15,26 @@
   when:
     - tmp_dep_dir is undefined
 
+- set_fact:
+    galaxy_requirements: "{{ dependencies.galaxy_requirements | default([]) }}"
+
+- name: "Compose galaxy_requirements file if galaxy_sources is set"
+  block:
+    - tempfile:
+        state: file
+        suffix: yml
+      register: tmp_galaxy_file
+    - template:
+        src: yaml_file.j2 
+        dest: "{{ tmp_galaxy_file }}"
+      vars:
+        yaml_content: "{{ dependencies.galaxy_sources }}"
+    - set_fact:
+        galaxy_requirements: "{{ galaxy_requirements + [ tmp_galaxy_file ] }}"
+  when:
+    - dependencies.galaxy_sources is defined
+    - dependencies.galaxy_sources|length > 0
+
 - name: "Run ansible-galaxy to pull in dependency roles"
   command: >
     ansible-galaxy install -r "{{ item }}" -p "{{ tmp_dep_dir }}"

--- a/roles/openshift-applier/tasks/install-dependencies.yml
+++ b/roles/openshift-applier/tasks/install-dependencies.yml
@@ -18,9 +18,6 @@
 - set_fact:
     galaxy_requirements: "{{ dependencies.galaxy_requirements | default([]) }}"
 
-- debug:
-    var: dependencies.galaxy_sources
-
 - name: "Compose galaxy_requirements file if galaxy_sources is set"
   block:
     - tempfile:
@@ -29,11 +26,11 @@
       register: tmp_galaxy_file
     - template:
         src: yaml_file.j2 
-        dest: "{{ tmp_galaxy_file }}"
+        dest: "{{ tmp_galaxy_file.path }}"
       vars:
         yaml_content: "{{ dependencies.galaxy_sources }}"
     - set_fact:
-        galaxy_requirements: "{{ galaxy_requirements + [ tmp_galaxy_file ] }}"
+        galaxy_requirements: "{{ galaxy_requirements + [ tmp_galaxy_file.path ] }}"
   when:
     - dependencies.galaxy_sources is defined
     - dependencies.galaxy_sources|length > 0
@@ -43,3 +40,12 @@
     ansible-galaxy install -r "{{ item }}" -p "{{ tmp_dep_dir }}"
   with_items:
     - "{{ dependencies.galaxy_requirements }}"
+
+- name: "Clean-up temporary file from above - if needed"
+  file:
+    path: "{{ tmp_galaxy_file.path }}"
+    state: absent
+  ignore_errors: True
+  when:
+    - tmp_galaxy_file is defined
+    - tmp_galaxy_file.path|trim != '' 

--- a/roles/openshift-applier/tasks/install-dependencies.yml
+++ b/roles/openshift-applier/tasks/install-dependencies.yml
@@ -18,11 +18,14 @@
 - set_fact:
     galaxy_requirements: "{{ dependencies.galaxy_requirements | default([]) }}"
 
+- debug:
+    var: dependencies.galaxy_sources
+
 - name: "Compose galaxy_requirements file if galaxy_sources is set"
   block:
     - tempfile:
         state: file
-        suffix: yml
+        suffix: .yml
       register: tmp_galaxy_file
     - template:
         src: yaml_file.j2 

--- a/roles/openshift-applier/tasks/main.yml
+++ b/roles/openshift-applier/tasks/main.yml
@@ -16,7 +16,7 @@
   loop_control:
     loop_var: dependencies
   when:
-    - dependencies.galaxy_requirements is defined
+    - (dependencies.galaxy_requirements is defined or dependencies.galaxy_sources is defined)
 
 - name: "Prepare to copy content to remote host(s) if not running 'locally'"
   import_tasks: prep-copy-inventory-to-remote.yml

--- a/roles/openshift-applier/templates/yaml_file.j2
+++ b/roles/openshift-applier/templates/yaml_file.j2
@@ -1,0 +1,4 @@
+---
+
+{{ yaml_content | to_nice_yaml }}
+

--- a/tests/inventories/pre-post-steps/group_vars/seed-hosts.yml
+++ b/tests/inventories/pre-post-steps/group_vars/seed-hosts.yml
@@ -4,6 +4,9 @@ molecule_test_inventory_skip: true
 
 openshift_cluster_content:
 - galaxy_requirements: "{{ inventory_dir }}/../../files/dependency/galaxy_requirements.yml"
+- galaxy_sources: # Duplicate of above, just to show an alternative approach
+  - src: https://github.com/redhat-cop/casl-ansible
+    version: master
 - object: projectrequest
   content:
   - name: "label-test-project"


### PR DESCRIPTION
#### What does this PR do?
Previously, the openshift-applier supported the use of `galaxy_requirements` - which pointed to a local file with galaxy requirements. This has presented some challenges in the cases where accessing a static file like this is difficult - for example with the use of Ansible Tower. This PR introduces a new variable, galaxy_sources, which will accept a yaml list of galaxy sources and compose a temporary file that will be used with ansible-galaxy. 

#### How should this be tested?
Define a list of `galaxy_sources` in the inventory and observe that these galaxy dependencies get pulled in and used correclty.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
