### PR TITLE
Updating the ANSIBLE_ROLES_PATH to allow role to be found

### DIFF
--- a/roles/openshift-applier/tasks/pre-post-step.yml
+++ b/roles/openshift-applier/tasks/pre-post-step.yml
@@ -16,7 +16,7 @@
 - name: "Add temporary path to the ANSIBLE_ROLES_PATH to let it find pre/post steps roles"
   setup:
   environment:
-    ANSIBLE_ROLES_PATH: "{{ tmp_dep_dir + ':' + lookup('env', 'ANSIBLE_ROLES_PATH') }}"
+    ANSIBLE_ROLES_PATH: "{{ tmp_dep_dir + ':' + saved_ansible_roles_path }}"
 
 - name: "Include the pre/post step role"
   include_role:

--- a/roles/openshift-applier/tasks/pre-post-step.yml
+++ b/roles/openshift-applier/tasks/pre-post-step.yml
@@ -10,13 +10,26 @@
   loop_control:
     loop_var: var
 
+- set_fact:
+    saved_ansible_roles_path: "{{ lookup('env', 'ANSIBLE_ROLES_PATH') }}"
+
+- name: "Add temporary path to the ANSIBLE_ROLES_PATH to let it find pre/post steps roles"
+  setup:
+  environment:
+    ANSIBLE_ROLES_PATH: "{{ tmp_dep_dir + ':' + lookup('env', 'ANSIBLE_ROLES_PATH') }}"
+
 - name: "Include the pre/post step role"
   include_role:
-    name: "{{ tmp_dep_dir }}{{ step.role }}"
+    name: "{{ step.role }}"
   when:
     - step is defined
     - step.role is defined
     - step.role|trim != ''
+
+- name: "Restore ANSIBLE_ROLES_PATH to remove temporary location"
+  setup:
+  environment:
+    ANSIBLE_ROLES_PATH: "{{ saved_ansible_roles_path }}"
 
 - name: "Clear facts to ensure that they don't carry over"
   set_fact:


### PR DESCRIPTION
#### What does this PR do?
This adds the temporary path to the `ANSIBLE_ROLES_PATH` environment variable to allow for playbooks in varying environments to find the dynamic pre/post roles. 

#### How should this be tested?
Run a playbook with a pre/post role - observe that the role works as expected.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
