### PR TITLE
Fix 3.0.4 issue if requirements not set

### DIFF
--- a/roles/openshift-applier/tasks/pre-post-step.yml
+++ b/roles/openshift-applier/tasks/pre-post-step.yml
@@ -17,6 +17,9 @@
   setup:
   environment:
     ANSIBLE_ROLES_PATH: "{{ tmp_dep_dir + ':' + saved_ansible_roles_path }}"
+  when:
+    - tmp_dep_dir is defined
+    - tmp_dep_dir|trim != ''
 
 - name: "Include the pre/post step role"
   include_role:


### PR DESCRIPTION
#### What does this PR do?
3.0.4 introduced a slight issue that if galaxy isn't used, the tmp_dep_dir variable is never set and so the openshift-applier role always crashes.  My fix just skips the affected task, but the surrounding logic looks like it would be ok (unnecessary round trip of the ANSIBLE_ROLES_PATH env variable, but not a big deal).

#### How should this be tested?
cp -r openshift-applier/roles . # current directory has a valid playbook
ansible-playbook -i hosts.yaml playbook.yaml

#### Is there a relevant Issue open for this?
Didn't open an issue.

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier @oybed 
