### PR TITLE
Extend wait-for-api to cover unsigned certificate situation

### DIFF
--- a/roles/wait-for-api/defaults/main.yml
+++ b/roles/wait-for-api/defaults/main.yml
@@ -2,4 +2,4 @@
 
 wait_for_api_delay: 15
 wait_for_api_retries: 30
-
+ignore_ssl_warnings: true

--- a/roles/wait-for-api/tasks/main.yml
+++ b/roles/wait-for-api/tasks/main.yml
@@ -1,10 +1,24 @@
 ---
 
-- name: Wait for the API call to be successful
-  command: >
-    {{ client | default(oc) }} get Ingress.config/cluster
-  register: ingress_info
-  retries: "{{ wait_for_api_retries }}" # Default value in defaults/main.yml
-  delay: "{{ wait_for_api_delay }}" # Default value in defaults/main.yml
-  until: not ingress_info.failed
+- name: Wait for the API call to be successful (ignore X509 warnings)
+  block:
+    - command: >
+         {{ client | default("oc") }} get Ingress.config/cluster
+      register: ingress_info
+      retries: "{{ wait_for_api_retries }}" # Default value in defaults/main.yml
+      delay: "{{ wait_for_api_delay }}" # Default value in defaults/main.yml
+      until:
+           - not ingress_info.failed
+  when: ignore_ssl_warnings
 
+- name: Wait for the API call to be successful (not ignoring X509 warnings)
+  block:
+    - command: >
+         {{ client | default("oc") }} get Ingress.config/cluster
+      register: ingress_info
+      retries: "{{ wait_for_api_retries }}" # Default value in defaults/main.yml
+      delay: "{{ wait_for_api_delay }}" # Default value in defaults/main.yml
+      until:
+           - "'certificate signed by unknown authority' not in ingress_info.stdout"
+           - not ingress_info.failed
+  when: not ignore_ssl_warnings


### PR DESCRIPTION

#### What does this PR do?
Improve wait-for-api-role to enable it to catch 'certificate signed by unknown authority' error.

#### How should this be tested?
Run the role against running Openshift environment, setting `ignore_ssl_errors` to desired value.

#### Is there a relevant Issue open for this?
N/A

#### Who would you like to review this?
cc: @redhat-cop/openshift-applier
